### PR TITLE
feat: `itemKey` support function

### DIFF
--- a/src/List.tsx
+++ b/src/List.tsx
@@ -43,7 +43,7 @@ export interface ListProps<T> extends React.HTMLAttributes<any> {
   data: T[];
   height?: number;
   itemHeight?: number;
-  itemKey: string;
+  itemKey: string | ((item: T) => string);
   component?: string | React.FC<any> | React.ComponentClass<any>;
   disabled?: boolean;
 
@@ -396,7 +396,8 @@ class List<T> extends React.Component<ListProps<T>, ListState<T>> {
 
   public getItemKey = (item: T, props?: Partial<ListProps<T>>) => {
     const { itemKey } = props || this.props;
-    return item ? item[itemKey] : null;
+
+    return typeof itemKey === 'function' ? itemKey(item) : item[itemKey];
   };
 
   /**

--- a/tests/props.test.js
+++ b/tests/props.test.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import List from '../src';
+
+describe('Props', () => {
+  it('itemKey is a function', () => {
+    class Item extends React.Component {
+      render() {
+        return this.props.children;
+      }
+    }
+
+    const wrapper = mount(
+      <List data={[{ id: 903 }, { id: 1128 }]} itemKey={item => item.id}>
+        {({ id }) => <Item>{id}</Item>}
+      </List>,
+    );
+
+    expect(
+      wrapper
+        .find(Item)
+        .at(0)
+        .key(),
+    ).toBe('903');
+
+    expect(
+      wrapper
+        .find(Item)
+        .at(1)
+        .key(),
+    ).toBe('1128');
+  });
+});


### PR DESCRIPTION
`rc-tree` something tree node not provides `key`, we use `pos` instead.