### PR TITLE
fix: Only do align with 1 items

### DIFF
--- a/src/List.tsx
+++ b/src/List.tsx
@@ -184,7 +184,12 @@ class List<T> extends React.Component<ListProps<T>, ListState<T>> {
       // Should trigger `onSkipRender` to tell that diff component is not render in the list
       if (data.length > prevData.length) {
         const { startIndex, endIndex } = this.state;
-        if (onSkipRender && (changedItemIndex < startIndex || endIndex < changedItemIndex)) {
+        if (
+          onSkipRender &&
+          (changedItemIndex === null ||
+            changedItemIndex < startIndex ||
+            endIndex < changedItemIndex)
+        ) {
           onSkipRender();
         }
       }
@@ -263,7 +268,7 @@ class List<T> extends React.Component<ListProps<T>, ListState<T>> {
           this.lockScroll = false;
         });
       });
-    } else if (prevData.length !== data.length && height) {
+    } else if (prevData.length !== data.length && changedItemIndex !== null && height) {
       /**
        * Re-calculate the item position since `data` length changed.
        * [IMPORTANT] We use relative position calculate here.

--- a/tests/util.test.js
+++ b/tests/util.test.js
@@ -86,9 +86,19 @@ describe('Util', () => {
       it('small list', () => {
         expect(findListDiffIndex([0], [], num => num)).toEqual(0);
         expect(findListDiffIndex([0, 1], [0], num => num)).toEqual(1);
-        expect(findListDiffIndex([0, 1, 2], [0], num => num)).toEqual(1);
+        expect(findListDiffIndex([0, 1, 2], [0], num => num)).toEqual(null);
         expect(findListDiffIndex([], [0], num => num)).toEqual(0);
         expect(findListDiffIndex([0], [0, 1], num => num)).toEqual(1);
+      });
+
+      it('diff only 1', () => {
+        expect(findListDiffIndex([0, 1, 2], [], num => num)).toEqual(null);
+        expect(findListDiffIndex([0, 1, 2], [1, 2], num => num)).toEqual(0);
+        expect(findListDiffIndex([0, 1, 2], [0, 2], num => num)).toEqual(1);
+        expect(findListDiffIndex([0, 1, 2], [0, 1], num => num)).toEqual(2);
+        expect(findListDiffIndex([0, 1, 2], [0], num => num)).toEqual(null);
+        expect(findListDiffIndex([0, 1, 2], [1], num => num)).toEqual(null);
+        expect(findListDiffIndex([0, 1, 2], [2], num => num)).toEqual(null);
       });
     });
   });


### PR DESCRIPTION
Diff algorithm should match only 1 item diff instead of multiple content change.