### PR TITLE
feat: Support `scrollTo` item index

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,5 +7,6 @@ module.exports = {
     '@typescript-eslint/no-explicit-any': 0,
     'react/no-did-update-set-state': 0,
     'react/no-find-dom-node': 0,
+    'no-dupe-class-members': 0,
   },
 };

--- a/examples/basic.tsx
+++ b/examples/basic.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable jsx-a11y/label-has-associated-control, jsx-a11y/label-has-for */
 import * as React from 'react';
 import List from '../src/List';
 
@@ -5,27 +6,27 @@ interface Item {
   id: number;
 }
 
-const MyItem: React.FC<Item> = ({ id }, ref) => {
-  return (
-    <span
-      ref={ref}
-      style={{
-        border: '1px solid gray',
-        padding: '0 16px',
-        height: 30,
-        lineHeight: '30px',
-        boxSizing: 'border-box',
-        display: 'inline-block',
-      }}
-    >
-      {id}
-    </span>
-  );
-};
+const MyItem: React.FC<Item> = ({ id }, ref) => (
+  <span
+    ref={ref}
+    style={{
+      border: '1px solid gray',
+      padding: '0 16px',
+      height: 30,
+      lineHeight: '30px',
+      boxSizing: 'border-box',
+      display: 'inline-block',
+    }}
+  >
+    {id}
+  </span>
+);
 
 const ForwardMyItem = React.forwardRef(MyItem);
 
-class TestItem extends React.Component<{ id: number }> {
+class TestItem extends React.Component<{ id: number }, {}> {
+  state = {};
+
   render() {
     return <div style={{ lineHeight: '30px' }}>{this.props.id}</div>;
   }
@@ -45,6 +46,7 @@ const TYPES = [
 
 const Demo = () => {
   const [type, setType] = React.useState('dom');
+  const listRef = React.useRef<List>(null);
 
   return (
     <React.StrictMode>
@@ -65,6 +67,7 @@ const Demo = () => {
         ))}
 
         <List
+          ref={listRef}
           data={data}
           height={200}
           itemHeight={30}
@@ -75,16 +78,60 @@ const Demo = () => {
           }}
         >
           {(item, _, props) =>
-            type === 'dom' ? (
+            (type === 'dom' ? (
               <ForwardMyItem {...item} {...props} />
             ) : (
               <TestItem {...item} {...props} />
-            )
+            ))
           }
         </List>
+
+        <button
+          type="button"
+          onClick={() => {
+            listRef.current.scrollTo(500);
+          }}
+        >
+          Scroll To 100px
+        </button>
+        <button
+          type="button"
+          onClick={() => {
+            listRef.current.scrollTo({
+              index: 50,
+              align: 'top',
+            });
+          }}
+        >
+          Scroll To 50 (top)
+        </button>
+        <button
+          type="button"
+          onClick={() => {
+            listRef.current.scrollTo({
+              index: 50,
+              align: 'bottom',
+            });
+          }}
+        >
+          Scroll To 50 (bottom)
+        </button>
+        <button
+          type="button"
+          onClick={() => {
+            listRef.current.scrollTo({
+              index: 50,
+              align: 'auto',
+            });
+          }}
+        >
+          Scroll To 50 (auto)
+        </button>
       </div>
     </React.StrictMode>
   );
 };
 
 export default Demo;
+
+/* eslint-enable */

--- a/tests/list.test.js
+++ b/tests/list.test.js
@@ -1,0 +1,169 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import List from '../src';
+import Filler from '../src/Filler';
+import { spyElementPrototypes } from './utils/domHook';
+
+function genData(count) {
+  return new Array(count).fill(null).map((_, id) => ({ id }));
+}
+
+describe('List', () => {
+  function genList(props) {
+    let node = (
+      <List component="ul" itemKey="id" {...props}>
+        {({ id }) => <li>{id}</li>}
+      </List>
+    );
+
+    if (props.ref) {
+      node = <div>{node}</div>;
+    }
+
+    return mount(node);
+  }
+
+  describe('raw', () => {
+    it('without height', () => {
+      const wrapper = genList({ data: genData(1) });
+      expect(wrapper.find(Filler).props().offset).toBeFalsy();
+    });
+
+    it('height over itemHeight', () => {
+      const wrapper = genList({ data: genData(1), itemHeight: 1, height: 999 });
+
+      expect(wrapper.find(Filler).props().offset).toBeFalsy();
+    });
+  });
+
+  describe('virtual', () => {
+    let scrollTop = 0;
+    let mockElement;
+
+    beforeAll(() => {
+      mockElement = spyElementPrototypes(HTMLElement, {
+        offsetHeight: {
+          get: () => 20,
+        },
+        scrollHeight: {
+          get: () => 2000,
+        },
+        clientHeight: {
+          get: () => 100,
+        },
+        scrollTop: {
+          get: () => scrollTop,
+          set(_, val) {
+            scrollTop = val;
+          },
+        },
+      });
+    });
+
+    afterAll(() => {
+      mockElement.mockRestore();
+    });
+
+    it('scroll', () => {
+      // scroll to top
+      scrollTop = 0;
+      const wrapper = genList({ itemHeight: 20, height: 100, data: genData(100) });
+      expect(wrapper.find(Filler).props().height).toEqual(2000);
+      expect(wrapper.find(Filler).props().offset).toEqual(0);
+
+      // scrollTop to end
+      scrollTop = 2000 - 100;
+      wrapper.find('ul').simulate('scroll', {
+        scrollTop,
+      });
+      expect(wrapper.find(Filler).props().height).toEqual(2000);
+      expect(wrapper.find(Filler).props().offset + wrapper.find('li').length * 20).toEqual(2000);
+    });
+
+    it('render out of view', () => {
+      scrollTop = 0;
+      let data = genData(20);
+      const onSkipRender = jest.fn();
+      const wrapper = genList({ itemHeight: 20, height: 100, disabled: true, data, onSkipRender });
+
+      data = [{ id: 'beforeAll' }, ...data];
+      wrapper.setProps({ data });
+      expect(onSkipRender).not.toHaveBeenCalled();
+
+      wrapper.setProps({ disabled: false });
+      data = [...data, { id: 'afterAll' }];
+      wrapper.setProps({ data, disabled: true });
+      expect(onSkipRender).toHaveBeenCalled();
+    });
+  });
+
+  describe('status switch', () => {
+    let scrollTop = 0;
+    let scrollHeight = 0;
+
+    let mockLiElement;
+    let mockElement;
+
+    beforeAll(() => {
+      mockLiElement = spyElementPrototypes(HTMLLIElement, {
+        offsetHeight: {
+          get: () => 40,
+        },
+      });
+
+      mockElement = spyElementPrototypes(HTMLElement, {
+        scrollHeight: {
+          get: () => scrollHeight,
+        },
+        clientHeight: {
+          get: () => 100,
+        },
+        scrollTop: {
+          get: () => scrollTop,
+          set(_, val) {
+            scrollTop = val;
+          },
+        },
+      });
+    });
+
+    afterAll(() => {
+      mockElement.mockRestore();
+      mockLiElement.mockRestore();
+    });
+
+    it('raw to virtual', () => {
+      let data = genData(5);
+      const wrapper = genList({ itemHeight: 20, height: 100, data });
+
+      scrollHeight = 200;
+      scrollTop = 40;
+      wrapper.find('ul').simulate('scroll', {
+        scrollTop,
+      });
+
+      scrollHeight = 120;
+      data = [...data, { id: 'afterAll' }];
+      wrapper.setProps({ data });
+      expect(wrapper.find('ul').instance().scrollTop < 10).toBeTruthy();
+    });
+
+    it('virtual to raw', done => {
+      let data = genData(6);
+      const wrapper = genList({ itemHeight: 20, height: 100, data });
+
+      scrollHeight = 120;
+      scrollTop = 10;
+      wrapper.find('ul').simulate('scroll', {
+        scrollTop,
+      });
+
+      scrollHeight = 200;
+      data = data.slice(0, -1);
+      wrapper.setProps({ data });
+      expect(wrapper.find('ul').instance().scrollTop > 40).toBeTruthy();
+
+      setTimeout(done, 50);
+    });
+  });
+});

--- a/tests/scroll.test.js
+++ b/tests/scroll.test.js
@@ -1,14 +1,13 @@
 import React from 'react';
 import { mount } from 'enzyme';
 import List from '../src';
-import Filler from '../src/Filler';
 import { spyElementPrototypes } from './utils/domHook';
 
 function genData(count) {
   return new Array(count).fill(null).map((_, id) => ({ id }));
 }
 
-describe('List', () => {
+describe('List.Scroll', () => {
   function genList(props) {
     let node = (
       <List component="ul" itemKey="id" {...props}>
@@ -23,81 +22,7 @@ describe('List', () => {
     return mount(node);
   }
 
-  describe('raw', () => {
-    it('without height', () => {
-      const wrapper = genList({ data: genData(1) });
-      expect(wrapper.find(Filler).props().offset).toBeFalsy();
-    });
-
-    it('height over itemHeight', () => {
-      const wrapper = genList({ data: genData(1), itemHeight: 1, height: 999 });
-
-      expect(wrapper.find(Filler).props().offset).toBeFalsy();
-    });
-  });
-
-  describe('virtual', () => {
-    let scrollTop = 0;
-    let mockElement;
-
-    beforeAll(() => {
-      mockElement = spyElementPrototypes(HTMLElement, {
-        offsetHeight: {
-          get: () => 20,
-        },
-        scrollHeight: {
-          get: () => 2000,
-        },
-        clientHeight: {
-          get: () => 100,
-        },
-        scrollTop: {
-          get: () => scrollTop,
-          set(_, val) {
-            scrollTop = val;
-          },
-        },
-      });
-    });
-
-    afterAll(() => {
-      mockElement.mockRestore();
-    });
-
-    it('scroll', () => {
-      // scroll to top
-      scrollTop = 0;
-      const wrapper = genList({ itemHeight: 20, height: 100, data: genData(100) });
-      expect(wrapper.find(Filler).props().height).toEqual(2000);
-      expect(wrapper.find(Filler).props().offset).toEqual(0);
-
-      // scrollTop to end
-      scrollTop = 2000 - 100;
-      wrapper.find('ul').simulate('scroll', {
-        scrollTop,
-      });
-      expect(wrapper.find(Filler).props().height).toEqual(2000);
-      expect(wrapper.find(Filler).props().offset + wrapper.find('li').length * 20).toEqual(2000);
-    });
-
-    it('render out of view', () => {
-      scrollTop = 0;
-      let data = genData(20);
-      const onSkipRender = jest.fn();
-      const wrapper = genList({ itemHeight: 20, height: 100, disabled: true, data, onSkipRender });
-
-      data = [{ id: 'beforeAll' }, ...data];
-      wrapper.setProps({ data });
-      expect(onSkipRender).not.toHaveBeenCalled();
-
-      wrapper.setProps({ disabled: false });
-      data = [...data, { id: 'afterAll' }];
-      wrapper.setProps({ data, disabled: true });
-      expect(onSkipRender).toHaveBeenCalled();
-    });
-  });
-
-  describe('scrollTo', () => {
+  describe('scrollTo number', () => {
     const listRef = React.createRef();
     const wrapper = genList({ itemHeight: 20, height: 100, data: genData(100), ref: listRef });
 
@@ -107,26 +32,20 @@ describe('List', () => {
     });
   });
 
-  describe('status switch', () => {
-    let scrollTop = 0;
-    let scrollHeight = 0;
-
-    let mockLiElement;
+  describe('scrollTo item index', () => {
     let mockElement;
+    let scrollTop = 0;
 
     beforeAll(() => {
-      mockLiElement = spyElementPrototypes(HTMLLIElement, {
-        offsetHeight: {
-          get: () => 40,
-        },
-      });
-
       mockElement = spyElementPrototypes(HTMLElement, {
-        scrollHeight: {
-          get: () => scrollHeight,
+        offsetHeight: {
+          get: () => 20,
         },
         clientHeight: {
           get: () => 100,
+        },
+        scrollHeight: {
+          get: () => 400,
         },
         scrollTop: {
           get: () => scrollTop,
@@ -139,41 +58,49 @@ describe('List', () => {
 
     afterAll(() => {
       mockElement.mockRestore();
-      mockLiElement.mockRestore();
     });
 
-    it('raw to virtual', () => {
-      let data = genData(5);
-      const wrapper = genList({ itemHeight: 20, height: 100, data });
+    function testPlots(type, props) {
+      describe(`${type} list`, () => {
+        let listRef;
 
-      scrollHeight = 200;
-      scrollTop = 40;
-      wrapper.find('ul').simulate('scroll', {
-        scrollTop,
+        beforeEach(() => {
+          listRef = React.createRef();
+          genList({ itemHeight: 20, height: 100, data: genData(20), ref: listRef, ...props });
+        });
+
+        it('top', () => {
+          listRef.current.scrollTo({ index: 10, align: 'top' });
+          expect(scrollTop).toEqual(200);
+        });
+        it('bottom', () => {
+          listRef.current.scrollTo({ index: 10, align: 'bottom' });
+          expect(scrollTop).toEqual(120);
+        });
+        describe('auto', () => {
+          it('upper of', () => {
+            scrollTop = 210;
+            listRef.current.onScroll();
+            listRef.current.scrollTo({ index: 10, align: 'auto' });
+            expect(scrollTop).toEqual(200);
+          });
+          it('lower of', () => {
+            scrollTop = 110;
+            listRef.current.onScroll();
+            listRef.current.scrollTo({ index: 10, align: 'auto' });
+            expect(scrollTop).toEqual(120);
+          });
+          it('in range', () => {
+            scrollTop = 150;
+            listRef.current.onScroll();
+            listRef.current.scrollTo({ index: 10, align: 'auto' });
+            expect(scrollTop).toEqual(150);
+          });
+        });
       });
+    }
 
-      scrollHeight = 120;
-      data = [...data, { id: 'afterAll' }];
-      wrapper.setProps({ data });
-      expect(wrapper.find('ul').instance().scrollTop < 10).toBeTruthy();
-    });
-
-    it('virtual to raw', done => {
-      let data = genData(6);
-      const wrapper = genList({ itemHeight: 20, height: 100, data });
-
-      scrollHeight = 120;
-      scrollTop = 10;
-      wrapper.find('ul').simulate('scroll', {
-        scrollTop,
-      });
-
-      scrollHeight = 200;
-      data = data.slice(0, -1);
-      wrapper.setProps({ data });
-      expect(wrapper.find('ul').instance().scrollTop > 40).toBeTruthy();
-
-      setTimeout(done, 50);
-    });
+    testPlots('virtual list');
+    testPlots('raw list', { itemHeight: null });
   });
 });

--- a/tests/util.test.js
+++ b/tests/util.test.js
@@ -84,6 +84,10 @@ describe('Util', () => {
         }
       });
 
+      it('both empty', () => {
+        expect(findListDiffIndex([], [], num => num)).toEqual(null);
+      });
+
       it('same list', () => {
         const list = [1, 2, 3, 4];
         expect(findListDiffIndex(list, list, num => num)).toEqual(null);

--- a/tests/utils/domHook.js
+++ b/tests/utils/domHook.js
@@ -1,11 +1,13 @@
 /* eslint-disable no-param-reassign */
+const NO_EXIST = { __NOT_EXIST: true };
+
 export function spyElementPrototypes(Element, properties) {
   const propNames = Object.keys(properties);
   const originDescriptors = {};
 
   propNames.forEach(propName => {
     const originDescriptor = Object.getOwnPropertyDescriptor(Element.prototype, propName);
-    originDescriptors[propName] = originDescriptor;
+    originDescriptors[propName] = originDescriptor || NO_EXIST;
 
     const spyProp = properties[propName];
 
@@ -39,7 +41,9 @@ export function spyElementPrototypes(Element, properties) {
     mockRestore() {
       propNames.forEach(propName => {
         const originDescriptor = originDescriptors[propName];
-        if (typeof originDescriptor === 'function') {
+        if (originDescriptor === NO_EXIST) {
+          delete Element.prototype[propName];
+        } else if (typeof originDescriptor === 'function') {
           Element.prototype[propName] = originDescriptor;
         } else {
           Object.defineProperty(Element.prototype, propName, originDescriptor);


### PR DESCRIPTION
In rc-select, we should support open to scroll to the active item:
```jsx
listRef.current.scrollTo({ index: 233, align: 'auto' });
```

Support `align`:
* auto
* top
* bottom