### PR TITLE
Add overscanCount option

### DIFF
--- a/src/List.tsx
+++ b/src/List.tsx
@@ -66,6 +66,10 @@ export interface ListProps<T> extends React.HTMLAttributes<any> {
   disabled?: boolean;
   /** Set `false` will always use real scroll instead of virtual one */
   virtual?: boolean;
+  /** How many additional (non-visible) items to render on each side, for reducing blank spaces
+   * flashing
+   */
+  overscanCount?: number;
 
   /** When `disabled`, trigger if changed item not render. */
   onSkipRender?: () => void;
@@ -748,6 +752,7 @@ class List<T = any> extends React.Component<ListProps<T>, ListState<T>> {
       onSkipRender,
       disabled,
       virtual,
+      overscanCount,
       ...restProps
     } = this.props;
 
@@ -791,8 +796,10 @@ class List<T = any> extends React.Component<ListProps<T>, ListState<T>> {
       ...ScrollStyle,
     };
 
-    const { status, startIndex, endIndex, startItemTop } = this.state;
+    const { status, startItemTop } = this.state;
     const contentHeight = itemCount * itemHeight * ITEM_SCALE_RATE;
+    const startIndex = Math.max(this.state.startIndex - (overscanCount || 0), 0);
+    const endIndex = this.state.endIndex + (overscanCount || 0);
 
     return (
       <Component

--- a/tests/list.test.js
+++ b/tests/list.test.js
@@ -110,6 +110,23 @@ describe('List', () => {
       wrapper.setProps({ data, disabled: true });
       expect(onSkipRender).toHaveBeenCalled();
     });
+
+    it('renders a limited number of elements', () => {
+      const wrapper = genList({ itemHeight: 20, height: 100, data: genData(100) });
+
+      expect(wrapper.find('li')).toHaveLength(6);
+    });
+
+    it('renders additional items when using overscanCount', () => {
+      const wrapper = genList({
+        itemHeight: 20,
+        height: 100,
+        data: genData(100),
+        overscanCount: 2,
+      });
+
+      expect(wrapper.find('li')).toHaveLength(8);
+    });
   });
 
   describe('status switch', () => {


### PR DESCRIPTION
Other libraries allow adding overscan elements to the list to ensure
that list items do not visibly pop in when scrolling.
See: https://web.dev/virtualize-long-lists-react-window/#overscanning

Add a simple way to render additional items when rendering in virtual
mode. Also add a test.