### PR TITLE
fix(List): Cannot read property 'clientHeight' of null

### DIFF
--- a/src/List.tsx
+++ b/src/List.tsx
@@ -490,7 +490,7 @@ class List<T = any> extends React.Component<ListProps<T>, ListState<T>> {
         if (item) {
           const { clientHeight } = this.listRef.current;
 
-          if (isVirtual) {
+          if (isVirtual && this.listRef.current) {
             // Calculate related data
             const { itemIndex, itemOffsetPtg } = this.state;
             const { scrollTop } = this.listRef.current;


### PR DESCRIPTION
Fixes the following:

```
    TypeError: Cannot read property 'clientHeight' of null

      at node_modules/rc-virtual-list/lib/List.js:242:56
```
Usage:

```jsx
<Select
      labelInValue
      showSearch
      style={{ width: 250 }}
      options={options}
      placeholder="Select Country"
      filterOption={(input, option): boolean =>
        (option?.label as string).toLowerCase().includes(input.toLowerCase())
      }
      onChange={handleChange}
      value={countryValue}
/>
```

Ant Design version: 4.3.1 (latest)

cc @zombieJ