### PR TITLE
fix: rerender on wrapper height change

### DIFF
--- a/src/List.tsx
+++ b/src/List.tsx
@@ -203,7 +203,17 @@ class List<T = any> extends React.Component<ListProps<T>, ListState<T>> {
       const diff = findListDiffIndex(prevData, data, this.getItemKey);
       changedItemIndex = diff ? diff.index : null;
     }
+    /** check if height changed */
+    if (this.cachedProps.height < height) {
+      const scrollPtg = getElementScrollPercentage(this.listRef.current);
+      const visibleCount = Math.ceil(height / itemHeight);
 
+      const { startIndex, endIndex } = getRangeIndex(scrollPtg, data.length, visibleCount);
+      this.setState({
+        startIndex,
+        endIndex,
+      });
+    }
     if (disabled) {
       // Should trigger `onSkipRender` to tell that diff component is not render in the list
       if (data.length > prevData.length) {

--- a/tests/list.test.js
+++ b/tests/list.test.js
@@ -110,6 +110,16 @@ describe('List', () => {
       wrapper.setProps({ data, disabled: true });
       expect(onSkipRender).toHaveBeenCalled();
     });
+
+    it('should rerender rows when current height > previous height', () => {
+      scrollTop = 0;
+      const data = genData(100);
+      const wrapper = genList({ itemHeight: 20, height: 100, data, virtual: true });
+
+      wrapper.setProps({ height: 200 });
+      wrapper.update();
+      expect(wrapper.find('li').length).toEqual(11);
+    });
   });
 
   describe('status switch', () => {


### PR DESCRIPTION
**Fix** bug

>  Behavior : 

   When height of wrapper change, component doesn't rerender list of items

Related issue on ant/design repo https://github.com/ant-design/ant-design/issues/25960

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/39340860/89668600-b345df80-d8e6-11ea-9368-6bc6c868c6eb.gif)
 