### PR TITLE
Use object as map

### DIFF
--- a/examples/basic.tsx
+++ b/examples/basic.tsx
@@ -34,7 +34,7 @@ class TestItem extends React.Component<Item, {}> {
 }
 
 const data: Item[] = [];
-for (let i = 0; i < 200; i += 1) {
+for (let i = 0; i < 100000; i += 1) {
   data.push({
     id: String(i),
   });
@@ -47,17 +47,9 @@ const TYPES = [
 
 const Demo = () => {
   const [destroy, setDestroy] = React.useState(false);
-  const [visible, setVisible] = React.useState(false);
+  const [visible, setVisible] = React.useState(true);
   const [type, setType] = React.useState('dom');
   const listRef = React.useRef<ListRef>(null);
-
-  React.useEffect(() => {
-    if (visible) {
-      listRef.current.scrollTo({
-        index: 100,
-      });
-    }
-  }, [visible]);
 
   return (
     <React.StrictMode>

--- a/src/List.tsx
+++ b/src/List.tsx
@@ -62,7 +62,6 @@ export function RawList<T>(props: ListProps<T>, ref: React.Ref<ListRef>) {
     component: Component = 'div',
     ...restProps
   } = props;
-  console.time('render');
 
   // ================================= MISC =================================
   const inVirtual =
@@ -120,7 +119,6 @@ export function RawList<T>(props: ListProps<T>, ref: React.Ref<ListRef>) {
     let startOffset: number;
     let endIndex: number;
 
-    console.time('memo-render');
     const dataLen = mergedData.length;
     for (let i = 0; i < dataLen; i += 1) {
       const item = mergedData[i];
@@ -154,7 +152,6 @@ export function RawList<T>(props: ListProps<T>, ref: React.Ref<ListRef>) {
 
     // Give cache to improve scroll experience
     endIndex = Math.min(endIndex + 1, mergedData.length);
-    console.timeEnd('memo-render');
 
     return {
       scrollHeight: itemTop,
@@ -225,8 +222,6 @@ export function RawList<T>(props: ListProps<T>, ref: React.Ref<ListRef>) {
     children,
     sharedConfig,
   );
-
-  console.timeEnd('render');
 
   return (
     <Component

--- a/src/List.tsx
+++ b/src/List.tsx
@@ -62,6 +62,7 @@ export function RawList<T>(props: ListProps<T>, ref: React.Ref<ListRef>) {
     component: Component = 'div',
     ...restProps
   } = props;
+  console.time('render');
 
   // ================================= MISC =================================
   const inVirtual =
@@ -119,7 +120,9 @@ export function RawList<T>(props: ListProps<T>, ref: React.Ref<ListRef>) {
     let startOffset: number;
     let endIndex: number;
 
-    for (let i = 0; i < mergedData.length; i += 1) {
+    console.time('memo-render');
+    const dataLen = mergedData.length;
+    for (let i = 0; i < dataLen; i += 1) {
       const item = mergedData[i];
       const key = getKey(item);
 
@@ -151,6 +154,7 @@ export function RawList<T>(props: ListProps<T>, ref: React.Ref<ListRef>) {
 
     // Give cache to improve scroll experience
     endIndex = Math.min(endIndex + 1, mergedData.length);
+    console.timeEnd('memo-render');
 
     return {
       scrollHeight: itemTop,
@@ -221,6 +225,8 @@ export function RawList<T>(props: ListProps<T>, ref: React.Ref<ListRef>) {
     children,
     sharedConfig,
   );
+
+  console.timeEnd('render');
 
   return (
     <Component

--- a/src/hooks/useHeights.tsx
+++ b/src/hooks/useHeights.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { useRef } from 'react';
 import findDOMNode from 'rc-util/lib/Dom/findDOMNode';
 import { GetKey } from '../interface';
+import CacheMap from '../utils/CacheMap';
 
 type RefFunc = (instance: HTMLElement) => void;
 
@@ -9,10 +10,10 @@ export default function useHeights<T>(
   getKey: GetKey<T>,
   onItemAdd?: (item: T) => void,
   onItemRemove?: (item: T) => void,
-): [(item: T) => (instance: HTMLElement) => void, () => void, Map<React.Key, number>, number] {
+): [(item: T) => (instance: HTMLElement) => void, () => void, CacheMap, number] {
   const [updatedMark, setUpdatedMark] = React.useState(0);
   const instanceRef = useRef(new Map<React.Key, HTMLElement>());
-  const heightsRef = useRef(new Map<React.Key, number>());
+  const heightsRef = useRef(new CacheMap());
 
   const instanceFuncRef = useRef<Map<React.Key, RefFunc>>(new Map());
   function getInstanceRefFunc(item: T) {

--- a/src/hooks/useScrollTo.tsx
+++ b/src/hooks/useScrollTo.tsx
@@ -3,11 +3,12 @@ import * as React from 'react';
 import raf from 'rc-util/lib/raf';
 import { ScrollTo } from '../List';
 import { GetKey } from '../interface';
+import CacheMap from '../utils/CacheMap';
 
 export default function useScrollTo<T>(
   containerRef: React.RefObject<HTMLDivElement>,
   data: T[],
-  heights: Map<React.Key, number>,
+  heights: CacheMap,
   itemHeight: number,
   getKey: GetKey<T>,
   collectHeight: () => void,

--- a/src/utils/CacheMap.ts
+++ b/src/utils/CacheMap.ts
@@ -1,0 +1,25 @@
+import React from 'react';
+
+// Firefox has low performance of map.
+class CacheMap {
+  maps: Record<string, number>;
+
+  constructor() {
+    this.maps = {};
+    this.maps.prototype = null;
+  }
+
+  set(key: React.ReactText, value: number) {
+    this.maps[key] = value;
+  }
+
+  get(key: React.ReactText) {
+    return this.maps[key];
+  }
+
+  delete(key: React.ReactText) {
+    delete this.maps[key];
+  }
+}
+
+export default CacheMap;

--- a/src/utils/CacheMap.ts
+++ b/src/utils/CacheMap.ts
@@ -16,10 +16,6 @@ class CacheMap {
   get(key: React.ReactText) {
     return this.maps[key];
   }
-
-  delete(key: React.ReactText) {
-    delete this.maps[key];
-  }
 }
 
 export default CacheMap;


### PR DESCRIPTION
Firefox 下 Map 的查询命中失败性能下降约 `~0.3 ns`。10w 条数据量累计下来会有接近 `20 ~ 30 ms` 的卡顿，倒是 object 没有这个神奇的问题，推测是内部实现 Map 的 key 需要遍历查询有关。Chrome 下会损失 1~2 ms 的渲染性能，问题不大。换了。

resolve https://github.com/ant-design/ant-design/pull/26278
