### PR TITLE
fix: make `isFF` checking isomorphic (resolve error on nodejs `ReferenceError: navigator is not defined`)

### DIFF
--- a/src/utils/isFirefox.ts
+++ b/src/utils/isFirefox.ts
@@ -1,3 +1,2 @@
-const isFF = typeof navigator === 'object' && /Firefox/i.test(navigator.userAgent);
-
+const isFF = typeof navigator !== 'undefined' && /Firefox/i.test(navigator.userAgent);
 export default isFF;


### PR DESCRIPTION
Fix SSR
```
vpc-admin: [dev] ReferenceError: navigator is not defined
vpc-admin: [dev]     at Object.<anonymous> (/vpc/apps/admin/node_modules/rc-virtual-list/lib/utils/isFirefox.js:7:28)
vpc-admin: [dev]     at Module._compile (internal/modules/cjs/loader.js:778:30)
vpc-admin: [dev]     at Object.Module._extensions..js (internal/modules/cjs/loader.js:789:10)
vpc-admin: [dev]     at Module.load (internal/modules/cjs/loader.js:653:32)
vpc-admin: [dev]     at tryModuleLoad (internal/modules/cjs/loader.js:593:12)
vpc-admin: [dev]     at Function.Module._load (internal/modules/cjs/loader.js:585:3)
vpc-admin: [dev]     at Module.require (internal/modules/cjs/loader.js:692:17)
vpc-admin: [dev]     at require (internal/modules/cjs/helpers.js:25:18)
vpc-admin: [dev]     at Object.<anonymous> (//vpc/apps/admin/node_modules/rc-virtual-list/lib/hooks/useFrameWheel.js:12:41)
vpc-admin: [dev]     at Module._compile (internal/modules/cjs/loader.js:778:30)
```