### PR TITLE
enhance scrollTo ts type

### DIFF
--- a/src/List.tsx
+++ b/src/List.tsx
@@ -31,7 +31,7 @@ export type ScrollConfig =
       align?: ScrollAlign;
       offset?: number;
     };
-export type ScrollTo = (arg: number | ScrollConfig) => void;
+export type ScrollTo = (arg?: number | ScrollConfig | null) => void;
 export type ListRef = {
   scrollTo: ScrollTo;
 };


### PR DESCRIPTION
`useScrollTo` 支持主动触发显示滚动条，但是 ts 中未导出定义。

https://github.com/react-component/virtual-list/blob/a6687b8bbc9b79ee6fa427a5b6a9926b73fb4128/src/hooks/useScrollTo.tsx#L21-L25

而且在 [`react-component/select`](https://github.com/react-component/select/blob/4b7cb3343902e2db2b63e9e7149e3dbbf61a3c83/src/OptionList.tsx#L157-L160) 有使用。
