### PR TITLE
fix: wheel handler set passive false

### DIFF
--- a/src/List.tsx
+++ b/src/List.tsx
@@ -268,7 +268,9 @@ export function RawList<T>(props: ListProps<T>, ref: React.Ref<ListRef>) {
       }
     }
 
-    componentRef.current.addEventListener('wheel', onRawWheel);
+    componentRef.current.addEventListener('wheel', onRawWheel, {
+      passive: false,
+    });
     componentRef.current.addEventListener('DOMMouseScroll', onFireFoxScroll as any);
     componentRef.current.addEventListener('MozMousePixelScroll', onMozMousePixelScroll);
 


### PR DESCRIPTION
List.js:248 
[Violation] Added non-passive event listener to a scroll-blocking 'wheel' event. Consider marking event handler as 'passive' to make the page more responsive. See https://www.chromestatus.com/feature/5745543795965952

when use preventDefault in wheel event handler, should set passive false