### PR TITLE
fix: touchend event not fired when long press selection

### DIFF
--- a/src/hooks/useMobileTouchMove.ts
+++ b/src/hooks/useMobileTouchMove.ts
@@ -49,7 +49,7 @@ export default function useMobileTouchMove(
   const onTouchStart = (e: TouchEvent) => {
     cleanUpEvents();
 
-    if (e.touches.length === 1 && !touchedRef.current) {
+    if (e.touches.length === 1) {
       touchedRef.current = true;
       touchYRef.current = Math.ceil(e.touches[0].pageY);
 


### PR DESCRIPTION
Change-Id: Icaad4860dd895b6107cb4c6010b3e72b2b012399

Long presses, a default ''Action Menu'' pops up, block touchend event firing up, touchedRef.current will always be true, cause unable to scroll.