### PR TITLE
fix:  fix dependencies `rc-util` version

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,6 @@
   "dependencies": {
     "classnames": "^2.2.6",
     "rc-resize-observer": "^1.0.0",
-    "rc-util": "^5.0.7"
+    "rc-util": "^5.15.0"
   }
 }


### PR DESCRIPTION
The api `useLayoutEffect` depends on `rc-util` 5.15.0 version or later.