### PR TITLE
fix: check null ref before removeEventListener

### DIFF
--- a/src/ScrollBar.tsx
+++ b/src/ScrollBar.tsx
@@ -89,7 +89,7 @@ export default class ScrollBar extends React.Component<ScrollBarProps, ScrollBar
     window.removeEventListener('mousemove', this.onMouseMove);
     window.removeEventListener('mouseup', this.onMouseUp);
 
-      this.scrollbarRef.current?.removeEventListener('touchstart', this.onScrollbarTouchStart);
+    this.scrollbarRef.current?.removeEventListener('touchstart', this.onScrollbarTouchStart);
     
     if (this.thumbRef.current) {
       this.thumbRef.current.removeEventListener('touchstart', this.onMouseDown);

--- a/src/ScrollBar.tsx
+++ b/src/ScrollBar.tsx
@@ -89,10 +89,15 @@ export default class ScrollBar extends React.Component<ScrollBarProps, ScrollBar
     window.removeEventListener('mousemove', this.onMouseMove);
     window.removeEventListener('mouseup', this.onMouseUp);
 
-    this.scrollbarRef.current.removeEventListener('touchstart', this.onScrollbarTouchStart);
-    this.thumbRef.current.removeEventListener('touchstart', this.onMouseDown);
-    this.thumbRef.current.removeEventListener('touchmove', this.onMouseMove);
-    this.thumbRef.current.removeEventListener('touchend', this.onMouseUp);
+    if (this.scrollbarRef.current) {
+      this.scrollbarRef.current.removeEventListener('touchstart', this.onScrollbarTouchStart);
+    }
+    
+    if (this.thumbRef.current) {
+      this.thumbRef.current.removeEventListener('touchstart', this.onMouseDown);
+      this.thumbRef.current.removeEventListener('touchmove', this.onMouseMove);
+      this.thumbRef.current.removeEventListener('touchend', this.onMouseUp);
+    }
 
     raf.cancel(this.moveRaf);
   };

--- a/src/ScrollBar.tsx
+++ b/src/ScrollBar.tsx
@@ -89,9 +89,7 @@ export default class ScrollBar extends React.Component<ScrollBarProps, ScrollBar
     window.removeEventListener('mousemove', this.onMouseMove);
     window.removeEventListener('mouseup', this.onMouseUp);
 
-    if (this.scrollbarRef.current) {
-      this.scrollbarRef.current.removeEventListener('touchstart', this.onScrollbarTouchStart);
-    }
+      this.scrollbarRef.current?.removeEventListener('touchstart', this.onScrollbarTouchStart);
     
     if (this.thumbRef.current) {
       this.thumbRef.current.removeEventListener('touchstart', this.onMouseDown);


### PR DESCRIPTION
Fixes error "Cannot read property removeEventListener of null" 

Related issues: 
close https://github.com/react-component/virtual-list/pull/163
close https://github.com/ant-design/ant-design/issues/34816
close https://github.com/ant-design/ant-design/issues/35221
close #178