### PR TITLE
fix: to get exact height to avoid scrolling deviation

### DIFF
--- a/src/hooks/useHeights.tsx
+++ b/src/hooks/useHeights.tsx
@@ -4,6 +4,7 @@ import findDOMNode from 'rc-util/lib/Dom/findDOMNode';
 import raf from 'rc-util/lib/raf';
 import type { GetKey } from '../interface';
 import CacheMap from '../utils/CacheMap';
+import { getOuterHeight } from '../utils/outerHeight';
 
 export default function useHeights<T>(
   getKey: GetKey<T>,
@@ -26,9 +27,10 @@ export default function useHeights<T>(
       instanceRef.current.forEach((element, key) => {
         if (element && element.offsetParent) {
           const htmlElement = findDOMNode<HTMLElement>(element);
-          const { offsetHeight } = htmlElement;
-          if (heightsRef.current.get(key) !== offsetHeight) {
-            heightsRef.current.set(key, htmlElement.offsetHeight);
+          const outerHeight = getOuterHeight(htmlElement)
+
+          if (heightsRef.current.get(key) !== outerHeight) {
+            heightsRef.current.set(key, outerHeight);
           }
         }
       });

--- a/src/utils/outerHeight.ts
+++ b/src/utils/outerHeight.ts
@@ -1,5 +1,3 @@
-const isFF = typeof navigator === 'object' && /Firefox/i.test(navigator.userAgent);
-
 /**
  * To get exact height to avoid scrolling deviation
  */
@@ -8,7 +6,5 @@ export const getOuterHeight = (el: HTMLElement) => {
   const computedStyle = window.getComputedStyle(el); 
   height += parseInt(computedStyle.marginTop, 10);
   height += parseInt(computedStyle.marginBottom, 10);
-  height += parseInt(computedStyle.borderTopWidth, 10);
-  height += parseInt(computedStyle.borderBottomWidth, 10);
   return height;
 }

--- a/src/utils/outerHeight.ts
+++ b/src/utils/outerHeight.ts
@@ -1,0 +1,14 @@
+const isFF = typeof navigator === 'object' && /Firefox/i.test(navigator.userAgent);
+
+/**
+ * To get exact height to avoid scrolling deviation
+ */
+export const getOuterHeight = (el: HTMLElement) => {
+  let height = el.offsetHeight;
+  const computedStyle = window.getComputedStyle(el); 
+  height += parseInt(computedStyle.marginTop, 10);
+  height += parseInt(computedStyle.marginBottom, 10);
+  height += parseInt(computedStyle.borderTopWidth, 10);
+  height += parseInt(computedStyle.borderBottomWidth, 10);
+  return height;
+}


### PR DESCRIPTION
There will be a rolling deviation cause show is not complete when the item Element be setted `marginTop` or `marginBottom`.

![image](https://user-images.githubusercontent.com/26050644/165669400-0012a9d9-cdb4-4f09-a69f-84cc18955799.png)
