### PR TITLE
fix: fix useVirtual invalid in list work with autosizer

### DIFF
--- a/src/List.tsx
+++ b/src/List.tsx
@@ -79,7 +79,7 @@ export function RawList<T>(props: ListProps<T>, ref: React.Ref<ListRef>) {
   } = props;
 
   // ================================= MISC =================================
-  const useVirtual = !!(virtual !== false && height && itemHeight);
+  const useVirtual = !!(virtual !== false && typeof height === 'number' && itemHeight);
   const inVirtual = useVirtual && data && itemHeight * data.length > height;
 
   const [scrollTop, setScrollTop] = useState(0);


### PR DESCRIPTION
In [AutoSizer](https://github.com/bvaughn/react-virtualized/blob/master/source/AutoSizer/AutoSizer.js)

The height pass to children will must be 0, and next to real height. and in List, if `height === 0`, `useVirtual` will be `false`. And virtual effect will invalid and all list item will be render.

In your souce code, i think you did wanna to check whether height is a valid number, skip virtual if height not set and not a number. so i think a strict check is better than implicit type conversion.