### PR TITLE
fix: scrollbar  is shaking when dropdown scroll to bottom

### DIFF
--- a/src/List.tsx
+++ b/src/List.tsx
@@ -194,7 +194,7 @@ export function RawList<T>(props: ListProps<T>, ref: React.Ref<ListRef>) {
     lastStartIndex,
     lastEndIndex,
     fillerOffset,
-    maxScrollHeight,
+    maxScrollHeightRef,
   ] = useCalcuPosition(
     scrollToCacheState,
     fillerInnerRef,
@@ -234,15 +234,15 @@ export function RawList<T>(props: ListProps<T>, ref: React.Ref<ListRef>) {
   // =============================== In Range ===============================
   function keepInRange(newScrollTop: number) {
     let newTop = newScrollTop;
-    if (!Number.isNaN(maxScrollHeight.current)) {
-      newTop = Math.min(newTop, maxScrollHeight.current);
+    if (!Number.isNaN(maxScrollHeightRef.current)) {
+      newTop = Math.min(newTop, maxScrollHeightRef.current);
     }
     newTop = Math.max(newTop, 0);
     return newTop;
   }
 
   const isScrollAtTop = offsetTop <= 0;
-  const isScrollAtBottom = offsetTop >= maxScrollHeight.current;
+  const isScrollAtBottom = offsetTop >= maxScrollHeightRef.current;
 
   const originScroll = useOriginScroll(isScrollAtTop, isScrollAtBottom);
 

--- a/src/List.tsx
+++ b/src/List.tsx
@@ -137,7 +137,7 @@ export function RawList<T>(props: ListProps<T>, ref: React.Ref<ListRef>) {
       if (typeof itemKey === 'function') {
         return itemKey(item);
       }
-      return item?.[itemKey];
+      return item?.[itemKey as string];
     },
     [itemKey],
   );
@@ -430,7 +430,7 @@ export function RawList<T>(props: ListProps<T>, ref: React.Ref<ListRef>) {
   });
 
   // ================================ Render ================================
-  const listChidren = React.useMemo(() => {
+  const listChildren = React.useMemo(() => {
     const nextChildren = renderChildren(
       mergedData,
       start,
@@ -444,8 +444,8 @@ export function RawList<T>(props: ListProps<T>, ref: React.Ref<ListRef>) {
     if (scrollToCacheState === STABLE || start === lastStartIndex) {
       return nextChildren;
     } else {
-      // ========== measure `cachHeight` =============
-      const nextChldren = renderChildren(
+      // ========== measure `cacheHeight` =============
+      const nextChildrenWithScrollMeasure = renderChildren(
         mergedData,
         lastStartIndex,
         lastEndIndex,
@@ -455,16 +455,16 @@ export function RawList<T>(props: ListProps<T>, ref: React.Ref<ListRef>) {
         sharedConfig,
       );
 
-      const childrenKey = new Set(nextChldren.map((item) => item.key));
+      const childrenKey = new Set(nextChildrenWithScrollMeasure.map((item) => item.key));
       // de-duplicate to avoid `react` to render wrong nodes
       nextChildren.forEach((item) => {
         if (!childrenKey.has(item.key)) {
-          nextChldren.push(item);
+          nextChildrenWithScrollMeasure.push(item);
         }
       });
 
       // last children is always put on top, which due to `Filler`'s nodes is offseted by top,
-      return nextChldren;
+      return nextChildrenWithScrollMeasure;
     }
   }, [
     scrollToCacheState,
@@ -529,7 +529,7 @@ export function RawList<T>(props: ListProps<T>, ref: React.Ref<ListRef>) {
             rtl={isRTL}
             extra={extraContent}
           >
-            {listChidren}
+            {listChildren}
           </Filler>
         </Component>
       </ResizeObserver>

--- a/src/List.tsx
+++ b/src/List.tsx
@@ -23,7 +23,7 @@ import { useEvent } from 'rc-util';
 import { useGetSize } from './hooks/useGetSize';
 import type { ScrollToCacheState } from './utils/scrollToCacheState';
 import { MEASURE, STABLE } from './utils/scrollToCacheState';
-import { useCalcuPosition } from './hooks/useCalcuPosition';
+import useCalcPosition from './hooks/useCalcPosition';
 
 const EMPTY_DATA = [];
 
@@ -187,27 +187,20 @@ export function RawList<T>(props: ListProps<T>, ref: React.Ref<ListRef>) {
   );
 
   // ========================== Visible Calculation =========================
-  const [
-    scrollHeight,
-    start,
-    end,
-    lastStartIndex,
-    lastEndIndex,
-    fillerOffset,
-    maxScrollHeightRef,
-  ] = useCalcuPosition(
-    scrollToCacheState,
-    fillerInnerRef,
-    getKey,
-    inVirtual,
-    heights,
-    itemHeight,
-    useVirtual,
-    offsetTop,
-    mergedData,
-    heightUpdatedMark,
-    height,
-  );
+  const [scrollHeight, start, end, lastStartIndex, lastEndIndex, fillerOffset, maxScrollHeightRef] =
+    useCalcPosition(
+      scrollToCacheState,
+      fillerInnerRef,
+      getKey,
+      inVirtual,
+      heights,
+      itemHeight,
+      useVirtual,
+      offsetTop,
+      mergedData,
+      heightUpdatedMark,
+      height,
+    );
 
   rangeRef.current.start = start;
   rangeRef.current.end = end;
@@ -222,14 +215,14 @@ export function RawList<T>(props: ListProps<T>, ref: React.Ref<ListRef>) {
   const verticalScrollBarRef = useRef<ScrollBarRef>();
   const horizontalScrollBarRef = useRef<ScrollBarRef>();
 
-  const horizontalScrollBarSpinSize = React.useMemo(() => getSpinSize(size.width, scrollWidth), [
-    size.width,
-    scrollWidth,
-  ]);
-  const verticalScrollBarSpinSize = React.useMemo(() => getSpinSize(size.height, scrollHeight), [
-    size.height,
-    scrollHeight,
-  ]);
+  const horizontalScrollBarSpinSize = React.useMemo(
+    () => getSpinSize(size.width, scrollWidth),
+    [size.width, scrollWidth],
+  );
+  const verticalScrollBarSpinSize = React.useMemo(
+    () => getSpinSize(size.height, scrollHeight),
+    [size.height, scrollHeight],
+  );
 
   // =============================== In Range ===============================
   function keepInRange(newScrollTop: number) {

--- a/src/hooks/useCalcPosition.ts
+++ b/src/hooks/useCalcPosition.ts
@@ -3,7 +3,7 @@ import type { ScrollToCacheState } from '../utils/scrollToCacheState';
 import { MEASURE } from '../utils/scrollToCacheState';
 import React, { useRef } from 'react';
 
-export function useCalcuPosition<T>(
+export default function useCalcPosition<T>(
   scrollToCacheState: ScrollToCacheState,
   fillerInnerRef: React.MutableRefObject<HTMLDivElement>,
   getKey: (item: T) => React.Key,
@@ -17,16 +17,17 @@ export function useCalcuPosition<T>(
   height: number,
 ): [number, number, number, number, number, number, React.MutableRefObject<number>] {
   const lastScrollInfos = useRef<[number, number, number, number]>([0, 0, 0, 0]);
-  const [
-    lastScrollHeight,
-    lastfillerOffset,
-    lastStartIndex,
-    lastEndIndex,
-  ] = lastScrollInfos.current;
+  const [lastScrollHeight, lastFillerOffset, lastStartIndex, lastEndIndex] =
+    lastScrollInfos.current;
 
   const maxScrollHeightRef = useRef(-1);
 
-  const { scrollHeight, start, end, offset: fillerOffset } = React.useMemo(() => {
+  const {
+    scrollHeight,
+    start,
+    end,
+    offset: fillerOffset,
+  } = React.useMemo(() => {
     if (!useVirtual) {
       return {
         scrollHeight: undefined,
@@ -101,7 +102,7 @@ export function useCalcuPosition<T>(
 
       return {
         ...result,
-        offset: lastfillerOffset,
+        offset: lastFillerOffset,
         scrollHeight: lastScrollHeight,
       };
     }

--- a/src/hooks/useCalcuPosition.ts
+++ b/src/hooks/useCalcuPosition.ts
@@ -1,0 +1,125 @@
+import type CacheMap from '../utils/CacheMap';
+import type { ScrollToCacheState } from '../utils/scrollToCacheState';
+import { MEASURE } from '../utils/scrollToCacheState';
+import React, { useRef } from 'react';
+
+export function useCalcuPosition<T>(
+  scrollToCacheState: ScrollToCacheState,
+  fillerInnerRef: React.MutableRefObject<HTMLDivElement>,
+  getKey: (item: T) => React.Key,
+  inVirtual: boolean,
+  heights: CacheMap,
+  itemHeight: number,
+  useVirtual: boolean,
+  offsetTop: number,
+  mergedData: T[],
+  heightUpdatedMark: number,
+  height: number,
+): [number, number, number, number, number, number, React.MutableRefObject<number>] {
+  const lastScrollInfos = useRef<[number, number, number, number]>([0, 0, 0, 0]);
+  const [
+    lastScrollHeight,
+    lastfillerOffset,
+    lastStartIndex,
+    lastEndIndex,
+  ] = lastScrollInfos.current;
+
+  const maxScrollHeightRef = useRef(-1);
+
+  const { scrollHeight, start, end, offset: fillerOffset } = React.useMemo(() => {
+    if (!useVirtual) {
+      return {
+        scrollHeight: undefined,
+        start: 0,
+        end: mergedData.length - 1,
+        offset: undefined,
+      };
+    }
+
+    // Always use virtual scroll bar in avoid shaking
+    if (!inVirtual) {
+      return {
+        scrollHeight: fillerInnerRef.current?.offsetHeight || 0,
+        start: 0,
+        end: mergedData.length - 1,
+        offset: undefined,
+      };
+    }
+
+    let itemTop = 0;
+    let startIndex: number;
+    let startOffset: number;
+    let endIndex: number;
+
+    const dataLen = mergedData.length;
+    for (let i = 0; i < dataLen; i += 1) {
+      const item = mergedData[i];
+      const key = getKey(item);
+
+      const cacheHeight = heights.get(key);
+      const currentItemBottom = itemTop + (cacheHeight === undefined ? itemHeight : cacheHeight);
+
+      // Check item top in the range
+      if (currentItemBottom >= offsetTop && startIndex === undefined) {
+        startIndex = i;
+        startOffset = itemTop;
+      }
+
+      // Check item bottom in the range. We will render additional one item for motion usage
+      if (currentItemBottom > offsetTop + height && endIndex === undefined) {
+        endIndex = i;
+      }
+
+      itemTop = currentItemBottom;
+    }
+
+    // When scrollTop at the end but data cut to small count will reach this
+    if (startIndex === undefined) {
+      startIndex = 0;
+      startOffset = 0;
+
+      endIndex = Math.ceil(height / itemHeight);
+    }
+    if (endIndex === undefined) {
+      endIndex = mergedData.length - 1;
+    }
+
+    // Give cache to improve scroll experience
+    endIndex = Math.min(endIndex + 1, mergedData.length - 1);
+
+    const result = {
+      scrollHeight: itemTop,
+      start: startIndex,
+      end: endIndex,
+      offset: startOffset,
+    };
+
+    // scrollToCacheState means listChildren is not correct, just use last offset to avoid seeing nothing.
+    if (scrollToCacheState === MEASURE) {
+      // makes `keepInRange` pass new `offsetTop`
+      maxScrollHeightRef.current = Math.max(lastScrollHeight, itemTop) - height;
+
+      return {
+        ...result,
+        offset: lastfillerOffset,
+        scrollHeight: lastScrollHeight,
+      };
+    }
+
+    lastScrollInfos.current = [itemTop, startOffset, startIndex, endIndex];
+
+    return result;
+  }, [inVirtual, useVirtual, offsetTop, mergedData, heightUpdatedMark, height, scrollToCacheState]);
+
+  // =============================== maxScrollHeight for `In Range` ===============================
+  const maxScrollHeight = scrollHeight - height;
+  // init
+  if (maxScrollHeightRef.current === -1) {
+    maxScrollHeightRef.current = maxScrollHeight;
+  }
+  if (scrollToCacheState !== MEASURE) {
+    maxScrollHeightRef.current = maxScrollHeight;
+  }
+
+  return [scrollHeight, start, end, lastStartIndex, lastEndIndex, fillerOffset, maxScrollHeightRef];
+}

--- a/src/hooks/useScrollTo.tsx
+++ b/src/hooks/useScrollTo.tsx
@@ -3,6 +3,8 @@ import * as React from 'react';
 import raf from 'rc-util/lib/raf';
 import type { GetKey } from '../interface';
 import type CacheMap from '../utils/CacheMap';
+import { MEASURE, STABLE } from '../utils/scrollToCacheState';
+import type { ScrollToCacheState } from '../utils/scrollToCacheState';
 
 export type ScrollAlign = 'top' | 'bottom' | 'auto';
 
@@ -32,6 +34,7 @@ export default function useScrollTo<T>(
   collectHeight: () => void,
   syncScrollTop: (newTop: number) => void,
   triggerFlash: () => void,
+  setScrollToCacheState: (state: ScrollToCacheState) => void,
 ): (arg: number | ScrollTarget) => void {
   const scrollRef = React.useRef<number>();
 
@@ -62,6 +65,15 @@ export default function useScrollTo<T>(
       // We will retry 3 times in case dynamic height shaking
       const syncScroll = (times: number, targetAlign?: 'top' | 'bottom') => {
         if (times < 0 || !containerRef.current) return;
+
+        // ================== switch cacheState ===================
+        if (times === 3) {
+          setScrollToCacheState(MEASURE);
+        } else if (times === 0) {
+          setScrollToCacheState(STABLE);
+        }
+
+        // ================== calculate targetTop =================
 
         const height = containerRef.current.clientHeight;
         let needCollectHeight = false;

--- a/src/utils/renderChildren.tsx
+++ b/src/utils/renderChildren.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import type { SharedConfig, RenderFunc } from '../interface';
 import { Item } from '../Item';
 
-export default function useChildren<T>(
+export default function renderChildren<T>(
   list: T[],
   startIndex: number,
   endIndex: number,

--- a/src/utils/scrollToCacheState.ts
+++ b/src/utils/scrollToCacheState.ts
@@ -1,0 +1,5 @@
+export const STABLE = 0;
+export const MEASURE = 1;
+
+/** When calling the method scorllTo, if the corresponding node does not have a cache height needs to be calculated  */
+export type ScrollToCacheState = typeof STABLE | typeof MEASURE;


### PR DESCRIPTION
因为是cacheHeight影响了scrollHeight，导致useScrollTo这个hooks触发的三次scroll的offesetTop不同,所以我的思路是,当要加载远距离的节点并且该节点未访问时,先在当前的节点下预加载远距离节点,但不滚动,等远距离节点的缓存高度拿到后,再真正加载远距离节点和滚动
![image](https://github.com/react-component/virtual-list/assets/102608263/b619b81e-aefc-4983-af45-725e4489cbfb)
![image](https://github.com/react-component/virtual-list/assets/102608263/9a6aff78-9f96-4870-806c-de3c81c4cfcb)

close: https://github.com/ant-design/ant-design/issues/44100
