### PR TITLE
fix: `scrollTo` flash

### DIFF
--- a/examples/basic.tsx
+++ b/examples/basic.tsx
@@ -1,18 +1,17 @@
-/* eslint-disable jsx-a11y/label-has-associated-control, jsx-a11y/label-has-for */
 import * as React from 'react';
-import List, { ListRef } from '../src/List';
+import List, { type ListRef } from '../src/List';
 import './basic.less';
 
 interface Item {
-  id: string;
+  id: number;
 }
 
 const MyItem: React.ForwardRefRenderFunction<any, Item> = ({ id }, ref) => (
   <span
     ref={ref}
-    // style={{
-    //   // height: 30 + (id % 2 ? 0 : 10),
-    // }}
+    style={{
+      height: 30 + (id % 2 ? 0 : 10),
+    }}
     className="fixed-item"
     onClick={() => {
       console.log('Click:', id);
@@ -35,7 +34,7 @@ class TestItem extends React.Component<Item, {}> {
 const data: Item[] = [];
 for (let i = 0; i < 1000; i += 1) {
   data.push({
-    id: String(i),
+    id: i,
   });
 }
 
@@ -44,7 +43,7 @@ const TYPES = [
   { name: 'ref react node', type: 'react', component: TestItem },
 ];
 
-const onScroll: React.UIEventHandler<HTMLElement> = e => {
+const onScroll: React.UIEventHandler<HTMLElement> = (e) => {
   console.log('scroll:', e.currentTarget.scrollTop);
 };
 
@@ -160,7 +159,7 @@ const Demo = () => {
           type="button"
           onClick={() => {
             listRef.current.scrollTo({
-              key: '50',
+              key: 50,
               align: 'auto',
             });
           }}
@@ -171,7 +170,7 @@ const Demo = () => {
         <button
           type="button"
           onClick={() => {
-            setVisible(v => !v);
+            setVisible((v) => !v);
           }}
         >
           visible

--- a/src/List.tsx
+++ b/src/List.tsx
@@ -431,7 +431,7 @@ export function RawList<T>(props: ListProps<T>, ref: React.Ref<ListRef>) {
     heights,
     itemHeight,
     getKey,
-    collectHeight,
+    () => collectHeight(true),
     syncScrollTop,
     delayHideScrollBar,
   );

--- a/src/hooks/useScrollTo.tsx
+++ b/src/hooks/useScrollTo.tsx
@@ -86,7 +86,7 @@ export default function useScrollTo<T>(
         }
 
         // Check if need sync height (visible range has item not record height)
-        let leftHeight = height;
+        let leftHeight = mergedAlign === 'top' ? offset : height - offset;
         for (let i = maxLen; i >= 0; i -= 1) {
           const key = getKey(data[i]);
           const cacheHeight = heights.get(key);
@@ -104,6 +104,7 @@ export default function useScrollTo<T>(
 
         // Scroll to
         let targetTop: number | null = null;
+        let inView = false;
 
         switch (mergedAlign) {
           case 'top':
@@ -120,16 +121,25 @@ export default function useScrollTo<T>(
               newTargetAlign = 'top';
             } else if (itemBottom > scrollBottom) {
               newTargetAlign = 'bottom';
+            } else {
+              // No need to collect since already in view
+              inView = true;
             }
           }
         }
 
-        console.log('sync top:', targetTop, containerRef.current.scrollTop);
+        console.log(
+          'sync top:',
+          targetTop,
+          containerRef.current.scrollTop,
+          mergedAlign,
+          newTargetAlign,
+        );
 
         if (targetTop !== null) {
           console.log('sss!');
           syncScrollTop(targetTop);
-        } else {
+        } else if (!inView) {
           needCollectHeight = true;
         }
       }

--- a/src/hooks/useScrollTo.tsx
+++ b/src/hooks/useScrollTo.tsx
@@ -49,7 +49,6 @@ export default function useScrollTo<T>(
 
   // ========================== Sync Scroll ==========================
   useLayoutEffect(() => {
-    console.log('🚨 Effect!', syncState?.times, '~~~~~~~~~~~~~~~~~');
     if (syncState && syncState.times < MAX_TIMES) {
       // Never reach
       if (!containerRef.current) {
@@ -128,23 +127,13 @@ export default function useScrollTo<T>(
           }
         }
 
-        console.log(
-          'sync top:',
-          targetTop,
-          containerRef.current.scrollTop,
-          mergedAlign,
-          newTargetAlign,
-        );
-
         if (targetTop !== null) {
-          console.log('sss!');
           syncScrollTop(targetTop);
         } else if (!inView) {
           needCollectHeight = true;
         }
       }
 
-      console.log('Need?', needCollectHeight);
       // Trigger next effect
       if (needCollectHeight) {
         setSyncState((ori) => ({

--- a/src/hooks/useScrollTo.tsx
+++ b/src/hooks/useScrollTo.tsx
@@ -3,6 +3,9 @@ import * as React from 'react';
 import raf from 'rc-util/lib/raf';
 import type { GetKey } from '../interface';
 import type CacheMap from '../utils/CacheMap';
+import useLayoutEffect from 'rc-util/lib/hooks/useLayoutEffect';
+
+const MAX_TIMES = 3;
 
 export type ScrollAlign = 'top' | 'bottom' | 'auto';
 
@@ -35,6 +38,94 @@ export default function useScrollTo<T>(
 ): (arg: number | ScrollTarget) => void {
   const scrollRef = React.useRef<number>();
 
+  const [syncState, setSyncState] = React.useState<{
+    times: number;
+    index: number;
+    offset: number;
+    originAlign: ScrollAlign;
+    targetAlign?: 'top' | 'bottom';
+  }>(null);
+
+  // ========================== Sync Scroll ==========================
+  useLayoutEffect(() => {
+    if (syncState && syncState.times < MAX_TIMES) {
+      // Never reach
+      if (!containerRef.current) {
+        setSyncState((ori) => ({ ...ori }));
+        return;
+      }
+
+      const { targetAlign, originAlign, index, offset } = syncState;
+
+      const height = containerRef.current.clientHeight;
+      let needCollectHeight = false;
+      let newTargetAlign: 'top' | 'bottom' | null = targetAlign;
+
+      // Go to next frame if height not exist
+      if (height) {
+        const mergedAlign = targetAlign || originAlign;
+
+        // Get top & bottom
+        let stackTop = 0;
+        let itemTop = 0;
+        let itemBottom = 0;
+
+        const maxLen = Math.min(data.length, index);
+
+        for (let i = 0; i <= maxLen; i += 1) {
+          const key = getKey(data[i]);
+          itemTop = stackTop;
+          const cacheHeight = heights.get(key);
+          itemBottom = itemTop + (cacheHeight === undefined ? itemHeight : cacheHeight);
+
+          stackTop = itemBottom;
+
+          if (i === index && cacheHeight === undefined) {
+            needCollectHeight = true;
+          }
+        }
+
+        // Scroll to
+        let targetTop: number | null = null;
+
+        switch (mergedAlign) {
+          case 'top':
+            targetTop = itemTop - offset;
+            break;
+          case 'bottom':
+            targetTop = itemBottom - height + offset;
+            break;
+
+          default: {
+            const { scrollTop } = containerRef.current;
+            const scrollBottom = scrollTop + height;
+            if (itemTop < scrollTop) {
+              newTargetAlign = 'top';
+            } else if (itemBottom > scrollBottom) {
+              newTargetAlign = 'bottom';
+            }
+          }
+        }
+
+        if (targetTop !== null && targetTop !== containerRef.current.scrollTop) {
+          syncScrollTop(targetTop);
+        }
+      }
+
+      // Trigger next effect
+      if (needCollectHeight) {
+        collectHeight();
+      }
+
+      setSyncState((ori) => ({
+        ...ori,
+        times: ori.times + 1,
+        targetAlign: newTargetAlign,
+      }));
+    }
+  }, [syncState, containerRef.current]);
+
+  // =========================== Scroll To ===========================
   return (arg) => {
     // When not argument provided, we think dev may want to show the scrollbar
     if (arg === null || arg === undefined) {
@@ -59,75 +150,12 @@ export default function useScrollTo<T>(
 
       const { offset = 0 } = arg;
 
-      // We will retry 3 times in case dynamic height shaking
-      const syncScroll = (times: number, targetAlign?: 'top' | 'bottom') => {
-        if (times < 0 || !containerRef.current) return;
-
-        const height = containerRef.current.clientHeight;
-        let needCollectHeight = false;
-        let newTargetAlign: 'top' | 'bottom' | null = targetAlign;
-
-        // Go to next frame if height not exist
-        if (height) {
-          const mergedAlign = targetAlign || align;
-
-          // Get top & bottom
-          let stackTop = 0;
-          let itemTop = 0;
-          let itemBottom = 0;
-
-          const maxLen = Math.min(data.length, index);
-
-          for (let i = 0; i <= maxLen; i += 1) {
-            const key = getKey(data[i]);
-            itemTop = stackTop;
-            const cacheHeight = heights.get(key);
-            itemBottom = itemTop + (cacheHeight === undefined ? itemHeight : cacheHeight);
-
-            stackTop = itemBottom;
-
-            if (i === index && cacheHeight === undefined) {
-              needCollectHeight = true;
-            }
-          }
-
-          // Scroll to
-          let targetTop: number | null = null;
-
-          switch (mergedAlign) {
-            case 'top':
-              targetTop = itemTop - offset;
-              break;
-            case 'bottom':
-              targetTop = itemBottom - height + offset;
-              break;
-
-            default: {
-              const { scrollTop } = containerRef.current;
-              const scrollBottom = scrollTop + height;
-              if (itemTop < scrollTop) {
-                newTargetAlign = 'top';
-              } else if (itemBottom > scrollBottom) {
-                newTargetAlign = 'bottom';
-              }
-            }
-          }
-
-          if (targetTop !== null && targetTop !== containerRef.current.scrollTop) {
-            syncScrollTop(targetTop);
-          }
-        }
-
-        // We will retry since element may not sync height as it described
-        scrollRef.current = raf(() => {
-          if (needCollectHeight) {
-            collectHeight();
-          }
-          syncScroll(times - 1, newTargetAlign);
-        }, 2); // Delay 2 to wait for List collect heights
-      };
-
-      syncScroll(3);
+      setSyncState({
+        times: 0,
+        index,
+        offset,
+        originAlign: align,
+      });
     }
   };
 }

--- a/tests/scroll.test.js
+++ b/tests/scroll.test.js
@@ -79,9 +79,6 @@ describe('List.Scroll', () => {
   });
 
   describe('scroll to object', () => {
-    const listRef = React.createRef();
-    const wrapper = genList({ itemHeight: 20, height: 100, data: genData(100), ref: listRef });
-
     function presetList() {
       const ref = React.createRef();
 
@@ -90,56 +87,55 @@ describe('List.Scroll', () => {
       return {
         ...result,
         ref,
+        scrollTo: (...args) => {
+          ref.current.scrollTo(...args);
+
+          act(() => {
+            jest.runAllTimers();
+          });
+        },
       };
     }
 
     describe('index scroll', () => {
       it('work in range', () => {
-        const { ref, container } = presetList();
+        const { scrollTo, container } = presetList();
 
-        ref.current.scrollTo({ index: 30, align: 'top' });
-
-        act(() => {
-          jest.runAllTimers();
-        });
+        scrollTo({ index: 30, align: 'top' });
 
         expect(container.querySelector('ul').scrollTop).toEqual(600);
       });
 
       it('out of range should not crash', () => {
         expect(() => {
-          const { ref } = presetList();
-          ref.current.scrollTo({ index: 99999999999, align: 'top' });
-
-          act(() => {
-            jest.runAllTimers();
-          });
+          const { scrollTo } = presetList();
+          scrollTo({ index: 99999999999, align: 'top' });
         }).not.toThrow();
       });
     });
 
     it('scroll top should not out of range', () => {
-      listRef.current.scrollTo({ index: 0, align: 'bottom' });
+      const { scrollTo, container } = presetList();
+      scrollTo({ index: 0, align: 'bottom' });
       jest.runAllTimers();
-      expect(wrapper.find('ul').instance().scrollTop).toEqual(0);
+      expect(container.querySelector('ul').scrollTop).toEqual(0);
     });
 
     it('key scroll', () => {
-      listRef.current.scrollTo({ key: '30', align: 'bottom' });
-      jest.runAllTimers();
-      expect(wrapper.find('ul').instance().scrollTop).toEqual(520);
+      const { scrollTo, container } = presetList();
+      scrollTo({ key: '30', align: 'bottom' });
+      expect(container.querySelector('ul').scrollTop).toEqual(520);
     });
 
     it('smart', () => {
-      listRef.current.scrollTo(0);
-      listRef.current.scrollTo({ index: 30 });
-      jest.runAllTimers();
-      expect(wrapper.find('ul').instance().scrollTop).toEqual(520);
+      const { scrollTo, container } = presetList();
+      scrollTo(0);
+      scrollTo({ index: 30 });
+      expect(container.querySelector('ul').scrollTop).toEqual(520);
 
-      listRef.current.scrollTo(800);
-      listRef.current.scrollTo({ index: 30 });
-      jest.runAllTimers();
-      expect(wrapper.find('ul').instance().scrollTop).toEqual(600);
+      scrollTo(800);
+      scrollTo({ index: 30 });
+      expect(container.querySelector('ul').scrollTop).toEqual(600);
     });
   });
 

--- a/tests/scroll.test.js
+++ b/tests/scroll.test.js
@@ -82,17 +82,38 @@ describe('List.Scroll', () => {
     const listRef = React.createRef();
     const wrapper = genList({ itemHeight: 20, height: 100, data: genData(100), ref: listRef });
 
+    function presetList() {
+      const ref = React.createRef();
+
+      const result = genList({ itemHeight: 20, height: 100, data: genData(100), ref }, render);
+
+      return {
+        ...result,
+        ref,
+      };
+    }
+
     describe('index scroll', () => {
-      it('work', () => {
-        listRef.current.scrollTo({ index: 30, align: 'top' });
-        jest.runAllTimers();
-        expect(wrapper.find('ul').instance().scrollTop).toEqual(600);
+      it('work in range', () => {
+        const { ref, container } = presetList();
+
+        ref.current.scrollTo({ index: 30, align: 'top' });
+
+        act(() => {
+          jest.runAllTimers();
+        });
+
+        expect(container.querySelector('ul').scrollTop).toEqual(600);
       });
 
       it('out of range should not crash', () => {
         expect(() => {
-          listRef.current.scrollTo({ index: 99999999999, align: 'top' });
-          jest.runAllTimers();
+          const { ref } = presetList();
+          ref.current.scrollTo({ index: 99999999999, align: 'top' });
+
+          act(() => {
+            jest.runAllTimers();
+          });
         }).not.toThrow();
       });
     });


### PR DESCRIPTION
ref https://github.com/react-component/virtual-list/pull/226/files#r1329877475

使用 `useEffectLayout` 进行滚动，从而跳过闪屏阶段 。

resolve: https://github.com/ant-design/ant-design/issues/44100