### PR TITLE
fix: scrollbar invisible

### DIFF
--- a/src/List.tsx
+++ b/src/List.tsx
@@ -265,7 +265,10 @@ export function RawList<T>(props: ListProps<T>, ref: React.Ref<ListRef>) {
   const [size, setSize] = React.useState({ width: 0, height });
 
   const onHolderResize: ResizeObserverProps['onResize'] = (sizeInfo) => {
-    setSize(sizeInfo);
+    setSize({
+      width: sizeInfo.width || sizeInfo.offsetWidth,
+      height: sizeInfo.height || sizeInfo.offsetHeight,
+    });
   };
 
   // Hack on scrollbar to enable flash call

--- a/tests/scroll.test.js
+++ b/tests/scroll.test.js
@@ -5,6 +5,8 @@ import { spyElementPrototypes } from './utils/domHook';
 import List from '../src';
 import { createEvent, fireEvent, render } from '@testing-library/react';
 import { resetWarned } from 'rc-util/lib/warning';
+import { _rs as onLibResize } from 'rc-resize-observer/lib/utils/observerUtil';
+import '@testing-library/jest-dom';
 
 function genData(count) {
   return new Array(count).fill(null).map((_, index) => ({ id: String(index) }));
@@ -12,6 +14,10 @@ function genData(count) {
 
 describe('List.Scroll', () => {
   let mockElement;
+  let boundingRect = {
+    width: 100,
+    height: 100,
+  };
 
   beforeAll(() => {
     mockElement = spyElementPrototypes(HTMLElement, {
@@ -21,10 +27,7 @@ describe('List.Scroll', () => {
       clientHeight: {
         get: () => 100,
       },
-      getBoundingClientRect: () => ({
-        width: 100,
-        height: 100,
-      }),
+      getBoundingClientRect: () => boundingRect,
       offsetParent: {
         get: () => document.body,
       },
@@ -36,6 +39,10 @@ describe('List.Scroll', () => {
   });
 
   beforeEach(() => {
+    boundingRect = {
+      width: 100,
+      height: 100,
+    };
     jest.useFakeTimers();
   });
 
@@ -435,5 +442,35 @@ describe('List.Scroll', () => {
         '.rc-virtual-list-scrollbar-vertical .rc-virtual-list-scrollbar-thumb',
       ).style.background,
     ).toEqual('blue');
+  });
+
+  it('scrollbar size should correct', async () => {
+    boundingRect = {
+      width: 0,
+      height: 0,
+    };
+
+    const { container } = genList(
+      {
+        itemHeight: 20,
+        height: 100,
+        data: genData(100),
+      },
+      render,
+    );
+
+    await act(async () => {
+      onLibResize([
+        {
+          target: container.querySelector('.rc-virtual-list-holder'),
+        },
+      ]);
+
+      await Promise.resolve();
+    });
+
+    expect(container.querySelector('.rc-virtual-list-scrollbar-thumb')).toHaveStyle({
+      height: `10px`,
+    });
   });
 });


### PR DESCRIPTION
v4 中的下拉框在动画启动时通过 `transform` 设置 `scaleY: 0`，导致 `onResize` 事件触发时设置容器高度为 `0` 而让滚动条 thumb 高度坍缩成 `0`。

而 v5 中，动画是从 `scaleY: 0.8` 开始。倒是 thumb 高度虽然不符合预期，但是仍然可以见到。

其中，不同 antd 版本的滚动条其实都是可以正常滚动。这个计算只影响 thumb 展示高度。

fix https://github.com/ant-design/ant-design/issues/45078