### PR TITLE
fix: dead loop in strict mode

### DIFF
--- a/src/hooks/useScrollTo.tsx
+++ b/src/hooks/useScrollTo.tsx
@@ -135,12 +135,12 @@ export default function useScrollTo<T>(
 
       // Trigger next effect
       if (needCollectHeight) {
-        setSyncState((ori) => ({
-          ...ori,
-          times: ori.times + 1,
+        setSyncState({
+          ...syncState,
+          times: syncState.times + 1,
           targetAlign: newTargetAlign,
           lastTop: targetTop,
-        }));
+        });
       }
     } else if (process.env.NODE_ENV !== 'production' && syncState?.times === MAX_TIMES) {
       warning(


### PR DESCRIPTION
resolve https://github.com/ant-design/ant-design/issues/45628

正常情况下直接设置和 func 设置应该是等价的：

```tsx
const [val, setVal] = useState(0);
useLayoutEffect(() => {
  if (val < 3) {
    setVal(val + 1); // Should same as: setVal(v => v + 1);
  }
}, [val]);
```

但是在 React StrictMode 中，回放出现了重叠：

```tsx
useLayoutEffect(() => {
  if (val < 3) {
    console.log('effect!');
    setVal(v => {
      console.log('🔥 state update!');
      return v + 1;
    });
  }
}, [val]);
```

`useLayoutEffect` 不会触发的情况下，`setVal` 会被调用然后认为可以触发 `useLayoutEffect` 导致无限循环：

<img width="134" alt="截屏2023-11-02 16 23 37" src="https://github.com/react-component/virtual-list/assets/5378891/27a5033e-e717-4157-819e-19e8fa2d0ba9">

这个行为直接写 codesandbox 不会出现：

https://codesandbox.io/s/vigorous-sea-vsr2ty?file=/src/App.tsx


差异在于死循环的 case 中多出了 batchUpdate：

#### 好的
<img width="401" alt="截屏2023-11-02 16 30 50" src="https://github.com/react-component/virtual-list/assets/5378891/1318daac-deff-4ac4-a725-02dd648727ba">

#### 坏的
<img width="768" alt="截屏2023-11-02 16 30 35" src="https://github.com/react-component/virtual-list/assets/5378891/3833074a-120e-4fbc-a552-95c2d658d156">

推测是复杂场景下，React 会将一批操作 Batch 掉。但是对于 StrictMode 下，effect 会多次执行确保开发者做了清理，导致 setState(action) 在 effect 周期外执行。从而导致了 update 触发了 effect 需要执行，而该 effect 又关联了 update 被回放导致死循环。

目前看起来，这是一个 StrictMode 的 BUG。仅做兜底处理。
