### PR TITLE
feat: onScroll add end param

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,7 @@ import List from 'rc-virtual-list';
 | itemHeight | Item minium height                                      | number                                                                                                                                                                                | -       |
 | itemKey    | Match key with item                                     | string                                                                                                                                                                                | -       |
 | styles     | style                                                   | { horizontalScrollBar?: React.CSSProperties; horizontalScrollBarThumb?: React.CSSProperties; verticalScrollBar?: React.CSSProperties; verticalScrollBarThumb?: React.CSSProperties; } | -       |
-| scrollEndOffset    | Scroll to end offset                                    | number                                                                                                                                                                        | 0       |
-| onScrollToEnd    | Scroll to bottom event                                     | `(e: React.UIEvent<HTMLDivElement>) => void`                                                                                                                                                                                | -       |
+| onScroll   | Support scroll to end parameter     | `(e: React.UIEvent<HTMLDivElement>, info: { end: boolean }) => void` 
 
 `children` provides additional `props` argument to support IE 11 scroll shaking.
 It will set `style` to `visibility: hidden` when measuring. You can ignore this if no requirement on IE.

--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ import List from 'rc-virtual-list';
 | itemHeight | Item minium height                                      | number                                                                                                                                                                                | -       |
 | itemKey    | Match key with item                                     | string                                                                                                                                                                                | -       |
 | styles     | style                                                   | { horizontalScrollBar?: React.CSSProperties; horizontalScrollBarThumb?: React.CSSProperties; verticalScrollBar?: React.CSSProperties; verticalScrollBarThumb?: React.CSSProperties; } | -       |
+| scrollEndOffset    | Scroll to end offset                                    | number                                                                                                                                                                        | 0       |
+| onScrollToEnd    | Scroll to bottom event                                     | `(e: React.UIEvent<HTMLDivElement>) => void`                                                                                                                                                                                | -       |
 
 `children` provides additional `props` argument to support IE 11 scroll shaking.
 It will set `style` to `visibility: hidden` when measuring. You can ignore this if no requirement on IE.

--- a/src/List.tsx
+++ b/src/List.tsx
@@ -73,6 +73,9 @@ export interface ListProps<T> extends Omit<React.HTMLAttributes<any>, 'children'
 
   onScroll?: React.UIEventHandler<HTMLElement>;
 
+  onScrollToEnd?: React.UIEventHandler<HTMLElement>;
+  scrollEndOffset?: number;
+
   /**
    * Given the virtual offset value.
    * It's the logic offset from start position.
@@ -110,6 +113,8 @@ export function RawList<T>(props: ListProps<T>, ref: React.Ref<ListRef>) {
     innerProps,
     extraRender,
     styles,
+    scrollEndOffset = 0,
+    onScrollToEnd,
     ...restProps
   } = props;
 
@@ -342,9 +347,18 @@ export function RawList<T>(props: ListProps<T>, ref: React.Ref<ListRef>) {
 
   // When data size reduce. It may trigger native scroll event back to fit scroll position
   function onFallbackScroll(e: React.UIEvent<HTMLDivElement>) {
-    const { scrollTop: newScrollTop } = e.currentTarget;
+    const {
+      scrollTop: newScrollTop,
+      offsetHeight,
+      scrollHeight: newScrollHeight,
+    } = e.currentTarget;
+
     if (newScrollTop !== offsetTop) {
       syncScrollTop(newScrollTop);
+    }
+
+    if (useVirtual && newScrollTop + offsetHeight + scrollEndOffset >= newScrollHeight) {
+      onScrollToEnd?.(e);
     }
 
     // Trigger origin onScroll

--- a/tests/list.test.js
+++ b/tests/list.test.js
@@ -102,25 +102,24 @@ describe('List.Basic', () => {
       expect(onVisibleChange.mock.calls[0][1]).toHaveLength(100);
     });
 
-    it('support onScrollToEnd and offset', () => {
-      const onScrollToEnd = jest.fn();
-      const scrollEndOffset = 200;
+    it('onScrll support end', (done) => {
+      const onScroll = jest.fn((_, info) => {
+        expect(info.end).toBe(true);
+        done();
+      });
 
       const wrapper = genList({
         itemHeight: 20,
         height: 100,
         data: genData(100),
-        scrollEndOffset,
-        onScrollToEnd,
+        onScroll,
       });
 
       // offsetHeight is 20, so add 80
-      scrollTop = 2000 - 100 - scrollEndOffset + 80;
+      scrollTop = 2000 - 100 + 80;
       wrapper.find('ul').simulate('scroll', {
         scrollTop,
       });
-
-      expect(onScrollToEnd).toBeCalled();
     });
   });
 

--- a/tests/list.test.js
+++ b/tests/list.test.js
@@ -101,6 +101,27 @@ describe('List.Basic', () => {
       expect(onVisibleChange.mock.calls[0][0]).toHaveLength(6);
       expect(onVisibleChange.mock.calls[0][1]).toHaveLength(100);
     });
+
+    it('support onScrollToEnd and offset', () => {
+      const onScrollToEnd = jest.fn();
+      const scrollEndOffset = 200;
+
+      const wrapper = genList({
+        itemHeight: 20,
+        height: 100,
+        data: genData(100),
+        scrollEndOffset,
+        onScrollToEnd,
+      });
+
+      // offsetHeight is 20, so add 80
+      scrollTop = 2000 - 100 - scrollEndOffset + 80;
+      wrapper.find('ul').simulate('scroll', {
+        scrollTop,
+      });
+
+      expect(onScrollToEnd).toBeCalled();
+    });
   });
 
   describe('status switch', () => {


### PR DESCRIPTION
ref: [ant-design/ant-design#44839](https://github.com/ant-design/ant-design/issues/44839)

为 `Table`、`Cascader` 和 `Select`  等使用 `rc-virtual-list` 的组件提供在虚拟滚动中的触底事件