### PR TITLE
fix: Math.floor touch offset

### DIFF
--- a/src/hooks/useMobileTouchMove.ts
+++ b/src/hooks/useMobileTouchMove.ts
@@ -45,7 +45,7 @@ export default function useMobileTouchMove(
         } else {
           offsetY *= SMOOTH_PTG;
         }
-        const offset = isHorizontal ? offsetX : offsetY;
+        const offset = Math.floor(isHorizontal ? offsetX : offsetY);
         if (!callback(isHorizontal, offset, true) || Math.abs(offset) <= 0.1) {
           clearInterval(intervalRef.current);
         }


### PR DESCRIPTION
![image](https://github.com/react-component/virtual-list/assets/47104575/31b387ab-5ebe-4e49-bb77-b2e3e7ada027)
有小数会导致 rc-table 会进入这段代码。
因为从 dom 获取 scrollLeft(target.scrollLeft) 总是整数，如果传入的有小数，会进入这段 hack 代码，会出现问题