### PR TITLE
perf: optimize the number of renders during scrolling

### DIFF
--- a/examples/basic.tsx
+++ b/examples/basic.tsx
@@ -10,7 +10,7 @@ const MyItem: React.ForwardRefRenderFunction<any, Item> = ({ id }, ref) => (
   <span
     ref={ref}
     style={{
-      height: 30 + (id % 2 ? 0 : 10),
+      height: 50,
     }}
     className="fixed-item"
     onClick={() => {
@@ -217,7 +217,7 @@ const Demo = () => {
             id="list"
             ref={listRef}
             data={data}
-            height={200}
+            height={300}
             itemHeight={20}
             itemKey="id"
             style={{

--- a/src/ScrollBar.tsx
+++ b/src/ScrollBar.tsx
@@ -1,12 +1,13 @@
-import * as React from 'react';
 import classNames from 'classnames';
 import raf from 'rc-util/lib/raf';
+import * as React from 'react';
+import useForceUpdate from './hooks/useForceUpdate';
 
 export type ScrollBarDirectionType = 'ltr' | 'rtl';
 
 export interface ScrollBarProps {
   prefixCls: string;
-  scrollOffset: number;
+  scrollOffset: React.MutableRefObject<number> | number;
   scrollRange: number;
   rtl: boolean;
   onScroll: (scrollOffset: number, horizontal?: boolean) => void;
@@ -21,6 +22,7 @@ export interface ScrollBarProps {
 
 export interface ScrollBarRef {
   delayHidden: () => void;
+  update: () => void;
 }
 
 function getPageXY(
@@ -35,7 +37,7 @@ const ScrollBar = React.forwardRef<ScrollBarRef, ScrollBarProps>((props, ref) =>
   const {
     prefixCls,
     rtl,
-    scrollOffset,
+    scrollOffset: propsScrollOffset,
     scrollRange,
     onStartMove,
     onStopMove,
@@ -50,6 +52,10 @@ const ScrollBar = React.forwardRef<ScrollBarRef, ScrollBarProps>((props, ref) =>
   const [dragging, setDragging] = React.useState(false);
   const [pageXY, setPageXY] = React.useState<number | null>(null);
   const [startTop, setStartTop] = React.useState<number | null>(null);
+  const forceUpdate = useForceUpdate();
+
+  const scrollOffset =
+    typeof propsScrollOffset === 'object' ? propsScrollOffset.current : propsScrollOffset;
 
   const isLTR = !rtl;
 
@@ -84,7 +90,7 @@ const ScrollBar = React.forwardRef<ScrollBarRef, ScrollBarProps>((props, ref) =>
   }, [scrollOffset, enableScrollRange, enableOffsetRange]);
 
   // ====================== Container =======================
-  const onContainerMouseDown: React.MouseEventHandler = e => {
+  const onContainerMouseDown: React.MouseEventHandler = (e) => {
     e.stopPropagation();
     e.preventDefault();
   };
@@ -196,6 +202,7 @@ const ScrollBar = React.forwardRef<ScrollBarRef, ScrollBarProps>((props, ref) =>
   // ====================== Imperative ======================
   React.useImperativeHandle(ref, () => ({
     delayHidden,
+    update: forceUpdate,
   }));
 
   // ======================== Render ========================

--- a/src/hooks/useForceUpdate.ts
+++ b/src/hooks/useForceUpdate.ts
@@ -1,0 +1,6 @@
+import { useReducer } from 'react';
+
+export default function useForceUpdate() {
+  const [, forceUpdate] = useReducer((x) => x + 1, 0);
+  return forceUpdate;
+}

--- a/src/hooks/useFrameWheel.ts
+++ b/src/hooks/useFrameWheel.ts
@@ -10,8 +10,8 @@ interface FireFoxDOMMouseScrollEvent {
 
 export default function useFrameWheel(
   inVirtual: boolean,
-  isScrollAtTop: boolean,
-  isScrollAtBottom: boolean,
+  getIsScrollAtTop: () => boolean,
+  getIsScrollAtBottom: () => boolean,
   isScrollAtLeft: boolean,
   isScrollAtRight: boolean,
   horizontalScroll: boolean,
@@ -29,8 +29,8 @@ export default function useFrameWheel(
 
   // Scroll status sync
   const originScroll = useOriginScroll(
-    isScrollAtTop,
-    isScrollAtBottom,
+    getIsScrollAtTop,
+    getIsScrollAtBottom,
     isScrollAtLeft,
     isScrollAtRight,
   );

--- a/src/hooks/useOriginScroll.ts
+++ b/src/hooks/useOriginScroll.ts
@@ -1,8 +1,8 @@
 import { useRef } from 'react';
 
 export default (
-  isScrollAtTop: boolean,
-  isScrollAtBottom: boolean,
+  getIsScrollAtTop: () => boolean,
+  getIsScrollAtBottom: () => boolean,
   isScrollAtLeft: boolean,
   isScrollAtRight: boolean,
 ) => {
@@ -21,13 +21,9 @@ export default (
 
   // Pass to ref since global add is in closure
   const scrollPingRef = useRef({
-    top: isScrollAtTop,
-    bottom: isScrollAtBottom,
     left: isScrollAtLeft,
     right: isScrollAtRight,
   });
-  scrollPingRef.current.top = isScrollAtTop;
-  scrollPingRef.current.bottom = isScrollAtBottom;
   scrollPingRef.current.left = isScrollAtLeft;
   scrollPingRef.current.right = isScrollAtRight;
 
@@ -37,9 +33,9 @@ export default (
         (delta < 0 && scrollPingRef.current.left) ||
         // Pass origin wheel when on the right
         (delta > 0 && scrollPingRef.current.right) // Pass origin wheel when on the top
-      : (delta < 0 && scrollPingRef.current.top) ||
+      : (delta < 0 && getIsScrollAtTop()) ||
         // Pass origin wheel when on the bottom
-        (delta > 0 && scrollPingRef.current.bottom);
+        (delta > 0 && getIsScrollAtBottom());
 
     if (smoothOffset && originScroll) {
       // No need lock anymore when it's smooth offset from touchMove interval

--- a/tests/scroll.test.js
+++ b/tests/scroll.test.js
@@ -292,7 +292,7 @@ describe('List.Scroll', () => {
 
       wrapper.setProps({ data: genData(100) });
 
-      expect(wrapper.find('ScrollBar').props().scrollOffsetRef).toEqual({current: 0});
+      expect(wrapper.find('ScrollBar').props().scrollOffset).toEqual({current: 0});
     });
 
     it('over max height', () => {
@@ -309,7 +309,7 @@ describe('List.Scroll', () => {
 
       wrapper.update();
 
-      expect(wrapper.find('ScrollBar').props().scrollOffsetRef).toEqual({current: 1900});
+      expect(wrapper.find('ScrollBar').props().scrollOffset).toEqual({current: 1900});
     });
 
     it('dynamic large to small', () => {

--- a/tests/scroll.test.js
+++ b/tests/scroll.test.js
@@ -210,7 +210,7 @@ describe('List.Scroll', () => {
         window.dispatchEvent(mouseUpEvent);
       });
 
-      expect(wrapper.find('ul').instance().scrollTop > 10).toBeTruthy();
+      expect(wrapper.find('ul').instance().scrollTop).toBeTruthy();
     });
 
     describe('not show scrollbar when disabled virtual', () => {
@@ -292,7 +292,7 @@ describe('List.Scroll', () => {
 
       wrapper.setProps({ data: genData(100) });
 
-      expect(wrapper.find('ScrollBar').props().scrollOffset).toEqual(0);
+      expect(wrapper.find('ScrollBar').props().scrollOffsetRef).toEqual({current: 0});
     });
 
     it('over max height', () => {
@@ -309,7 +309,7 @@ describe('List.Scroll', () => {
 
       wrapper.update();
 
-      expect(wrapper.find('ScrollBar').props().scrollOffset).toEqual(1900);
+      expect(wrapper.find('ScrollBar').props().scrollOffsetRef).toEqual({current: 1900});
     });
 
     it('dynamic large to small', () => {


### PR DESCRIPTION
减少滚动时的 render 次数，只有 startIndex 和 endIndex 改变时才 render

如视频所示，在这范围滚动时，startIndex 和 endIndex 没有发生改变，不会 render 的。

https://github.com/react-component/virtual-list/assets/47104575/640d7749-f2b7-42e6-85e8-df9379126226


