### PR TITLE
fix: can't scroll the document on Firefox

### DIFF
--- a/src/List.tsx
+++ b/src/List.tsx
@@ -425,8 +425,11 @@ export function RawList<T>(props: ListProps<T>, ref: React.Ref<ListRef>) {
 
   useLayoutEffect(() => {
     // Firefox only
-    function onMozMousePixelScroll(e: Event) {
-      if (useVirtual) {
+    function onMozMousePixelScroll(e: WheelEvent) {
+      // scrolling at top/bottom limit
+      const scrollingUpAtTop = isScrollAtTop && e.detail < 0;
+      const scrollingDownAtBottom = isScrollAtBottom && e.detail > 0;
+      if (useVirtual && !scrollingUpAtTop && !scrollingDownAtBottom) {
         e.preventDefault();
       }
     }
@@ -441,7 +444,7 @@ export function RawList<T>(props: ListProps<T>, ref: React.Ref<ListRef>) {
       componentEle.removeEventListener('DOMMouseScroll', onFireFoxScroll as any);
       componentEle.removeEventListener('MozMousePixelScroll', onMozMousePixelScroll as any);
     };
-  }, [useVirtual]);
+  }, [useVirtual, isScrollAtTop, isScrollAtBottom]);
 
   // Sync scroll left
   useLayoutEffect(() => {

--- a/tests/scroll-Firefox.test.js
+++ b/tests/scroll-Firefox.test.js
@@ -84,4 +84,59 @@ describe('List.Firefox-Scroll', () => {
     expect(wheelPreventDefault).not.toHaveBeenCalled();
     expect(firefoxPreventDefault).toHaveBeenCalledTimes(1);
   });
+
+  it('should call preventDefault on MozMousePixelScroll', () => {
+    const preventDefault = jest.fn();
+    const wrapper = genList({ itemHeight: 20, height: 100, data: genData(100) });
+    const ulElement = wrapper.find('ul').instance();
+
+    act(() => {
+      const event = new Event('MozMousePixelScroll');
+      event.detail = 6;
+      event.preventDefault = preventDefault;
+      ulElement.dispatchEvent(event);
+
+      jest.runAllTimers();
+    });
+
+    expect(preventDefault).toHaveBeenCalled();
+  });
+
+  it('should not call preventDefault on MozMousePixelScroll when scrolling up at top boundary', () => {
+    const preventDefault = jest.fn();
+    const wrapper = genList({ itemHeight: 20, height: 100, data: genData(100) });
+    const ulElement = wrapper.find('ul').instance();
+
+    act(() => {
+      const event = new Event('MozMousePixelScroll');
+      event.detail = -6;
+      event.preventDefault = preventDefault;
+      ulElement.dispatchEvent(event);
+
+      jest.runAllTimers();
+    });
+
+    expect(preventDefault).not.toHaveBeenCalled();
+  });
+  it('should not call preventDefault on MozMousePixelScroll when scrolling down at bottom boundary', () => {
+    const preventDefault = jest.fn();
+    const listRef = React.createRef();
+    const wrapper = genList({ itemHeight: 20, height: 100, data: genData(100), ref: listRef });
+    const ulElement = wrapper.find('ul').instance();
+    // scroll to bottom
+    listRef.current.scrollTo(99999);
+    jest.runAllTimers();
+    expect(wrapper.find('ul').instance().scrollTop).toEqual(1900);
+
+    act(() => {
+      const event = new Event('MozMousePixelScroll');
+      event.detail = 6;
+      event.preventDefault = preventDefault;
+      ulElement.dispatchEvent(event);
+
+      jest.runAllTimers();
+    });
+
+    expect(preventDefault).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

### 🤔 This is a ...

- [x] 🐞 Bug fix

### 🔗 Related Issues

> - close https://github.com/ant-design/ant-design/issues/49399

### 💡 Background and Solution

> - The scroll event is prevented on Firefox. Even when scrolling up during the list is already at top.
>- Solution: Don't prevent the scroll event when scrolling up/down on the List which is already at top/bottom


| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   fix: can't scroll the document on Firefox        |
| 🇨🇳 Chinese |      fix: 在Firefox浏览器中，无法滚动文档的问题     |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新特性**
	- 改进了Firefox浏览器中的鼠标滚动事件处理，增强了用户在滚动列表时的体验。
  
- **测试**
	- 增加了针对Firefox环境下滚动行为的新测试用例，提升了对边界情况下滚动行为的测试覆盖率。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->