### PR TITLE
fix: take margin into account

### DIFF
--- a/examples/switch.tsx
+++ b/examples/switch.tsx
@@ -16,6 +16,7 @@ const MyItem: React.FC<Item> = ({ id }, ref) => (
       lineHeight: '30px',
       boxSizing: 'border-box',
       display: 'inline-block',
+      // marginBottom: 8,
     }}
   >
     {id}

--- a/src/hooks/useHeights.tsx
+++ b/src/hooks/useHeights.tsx
@@ -1,9 +1,14 @@
-import * as React from 'react';
-import { useRef, useEffect } from 'react';
 import findDOMNode from 'rc-util/lib/Dom/findDOMNode';
 import raf from 'rc-util/lib/raf';
+import * as React from 'react';
+import { useEffect, useRef } from 'react';
 import type { GetKey } from '../interface';
 import CacheMap from '../utils/CacheMap';
+
+function parseNumber(value: string) {
+  const num = parseFloat(value);
+  return isNaN(num) ? 0 : num;
+}
 
 export default function useHeights<T>(
   getKey: GetKey<T>,
@@ -32,8 +37,14 @@ export default function useHeights<T>(
         if (element && element.offsetParent) {
           const htmlElement = findDOMNode<HTMLElement>(element);
           const { offsetHeight } = htmlElement;
-          if (heightsRef.current.get(key) !== offsetHeight) {
-            heightsRef.current.set(key, htmlElement.offsetHeight);
+          const { marginTop, marginBottom } = getComputedStyle(htmlElement);
+
+          const marginTopNum = parseNumber(marginTop);
+          const marginBottomNum = parseNumber(marginBottom);
+          const totalHeight = offsetHeight + marginTopNum + marginBottomNum;
+
+          if (heightsRef.current.get(key) !== totalHeight) {
+            heightsRef.current.set(key, totalHeight);
           }
         }
       });


### PR DESCRIPTION
ref https://github.com/ant-design/ant-design/issues/51485

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 引入了一个新的实用函数 `parseNumber`，用于将字符串转换为浮点数，以支持高度计算。
  
- **改进**
  - 更新了高度收集逻辑，考虑了元素的 `marginTop` 和 `marginBottom`，以提高布局和渲染的准确性。

- **样式**
  - 在 `MyItem` 组件中添加了一个注释，指示之前存在的样式属性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->