### PR TITLE
fix: scroll offset should not block

### DIFF
--- a/src/hooks/useScrollDrag.ts
+++ b/src/hooks/useScrollDrag.ts
@@ -10,7 +10,7 @@ export function getPageXY(
   horizontal: boolean,
 ) {
   const obj = 'touches' in e ? e.touches[0] : e;
-  return obj[horizontal ? 'pageX' : 'pageY'];
+  return obj[horizontal ? 'pageX' : 'pageY'] - window[horizontal ? 'scrollX' : 'scrollY'];
 }
 
 export default function useScrollDrag(


### PR DESCRIPTION
当 VirtualList 不是定格时，mouseY 和 getBoundingClientRect 的 top & bottom 是不一致的。需要减去滚动 offset。

PS: jsdom 无法测试这个。