### PR TITLE
fix: avoid table jitter casued by changes in the first row

### DIFF
--- a/src/utils/debounce.ts
+++ b/src/utils/debounce.ts
@@ -1,0 +1,10 @@
+export function debounce(fn: (...args) => void, delay: number = 300) {
+  let timer;
+  return function (...args) {
+    if (timer) clearTimeout(timer);
+    timer = setTimeout(() => {
+      fn.apply(this, args);
+      timer = null;
+    }, delay);
+  }
+}


### PR DESCRIPTION
ref [ant-design/ant-design#52418](https://github.com/ant-design/ant-design/issues/52418)

- ## Bug fix
- Fixed the table jitter casued by the change of the first row height