### PR TITLE
fix: add mergedData length check

### DIFF
--- a/src/List.tsx
+++ b/src/List.tsx
@@ -277,7 +277,7 @@ export function RawList<T>(props: ListProps<T>, ref: React.Ref<ListRef>) {
   // Let's sync scroll top to avoid jump
   React.useLayoutEffect(() => {
     const changedRecord = heights.getRecord();
-    if (changedRecord.size === 1) {
+    if (changedRecord.size === 1 && mergedData.length > 0) {
       const recordKey = Array.from(changedRecord)[0];
       const startIndexKey = getKey(mergedData[start]);
       if (startIndexKey === recordKey) {

--- a/src/List.tsx
+++ b/src/List.tsx
@@ -277,15 +277,19 @@ export function RawList<T>(props: ListProps<T>, ref: React.Ref<ListRef>) {
   // Let's sync scroll top to avoid jump
   React.useLayoutEffect(() => {
     const changedRecord = heights.getRecord();
-    if (changedRecord.size === 1 && mergedData.length > 0) {
+    if (changedRecord.size === 1) {
       const recordKey = Array.from(changedRecord)[0];
-      const startIndexKey = getKey(mergedData[start]);
-      if (startIndexKey === recordKey) {
-        const realStartHeight = heights.get(recordKey);
-        const diffHeight = realStartHeight - itemHeight;
-        syncScrollTop((ori) => {
-          return ori + diffHeight;
-        });
+      // Quick switch data may cause `start` not in `mergedData` anymore
+      const startItem = mergedData[start];
+      if (startItem) {
+        const startIndexKey = getKey(startItem);
+        if (startIndexKey === recordKey) {
+          const realStartHeight = heights.get(recordKey);
+          const diffHeight = realStartHeight - itemHeight;
+          syncScrollTop((ori) => {
+            return ori + diffHeight;
+          });
+        }
       }
     }
 


### PR DESCRIPTION
### Problem  
When `mergedData` updates rapidly, an issue occurs in `rc-virtual-list` where the component behaves unexpectedly due to missing length validation. 

reproduce link: https://codepen.io/hk-s/pen/dPyOxKx?editors=0011

### Solution  
Added a length check for `mergedData` in the `if` condition to prevent this issue.  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 更新后的发布说明

- **Bug Fixes**
  - 调整了列表视图的滚动逻辑，现在仅在存在可显示数据时才进行滚动调整，从而避免了无数据时出现的不必要滚动行为。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->