### PR TITLE
fix: Dynamic height bump the scroll pos in some edge case

### DIFF
--- a/src/List.tsx
+++ b/src/List.tsx
@@ -278,7 +278,7 @@ export function RawList<T>(props: ListProps<T>, ref: React.Ref<ListRef>) {
   React.useLayoutEffect(() => {
     const changedRecord = heights.getRecord();
     if (changedRecord.size === 1) {
-      const recordKey = changedRecord.keys()[0];
+      const recordKey = Array.from(changedRecord.keys())[0];
       const prevCacheHeight = changedRecord.get(recordKey);
 
       // Quick switch data may cause `start` not in `mergedData` anymore

--- a/src/List.tsx
+++ b/src/List.tsx
@@ -278,10 +278,12 @@ export function RawList<T>(props: ListProps<T>, ref: React.Ref<ListRef>) {
   React.useLayoutEffect(() => {
     const changedRecord = heights.getRecord();
     if (changedRecord.size === 1) {
-      const recordKey = Array.from(changedRecord)[0];
+      const recordKey = changedRecord.keys()[0];
+      const prevCacheHeight = changedRecord.get(recordKey);
+
       // Quick switch data may cause `start` not in `mergedData` anymore
       const startItem = mergedData[start];
-      if (startItem) {
+      if (startItem && prevCacheHeight === undefined) {
         const startIndexKey = getKey(startItem);
         if (startIndexKey === recordKey) {
           const realStartHeight = heights.get(recordKey);

--- a/src/utils/CacheMap.ts
+++ b/src/utils/CacheMap.ts
@@ -8,16 +8,18 @@ class CacheMap {
   // `useMemo` no need to update if `id` not change
   id: number = 0;
 
-  diffKeys = new Set<React.Key>();
+  diffRecords = new Map<React.Key, number>();
 
   constructor() {
     this.maps = Object.create(null);
   }
 
   set(key: React.Key, value: number) {
+    // Record prev value
+    this.diffRecords.set(key, this.maps[key as string]);
+
     this.maps[key as string] = value;
     this.id += 1;
-    this.diffKeys.add(key as string);
   }
 
   get(key: React.Key) {
@@ -29,11 +31,11 @@ class CacheMap {
    * To help to know what's update in the next render.
    */
   resetRecord() {
-    this.diffKeys.clear();
+    this.diffRecords.clear();
   }
 
   getRecord() {
-    return this.diffKeys;
+    return this.diffRecords;
   }
 }
 


### PR DESCRIPTION
fix https://github.com/ant-design/ant-design/issues/53334
close https://github.com/react-component/table/pull/1256

When the Item has already record the height (for height change), the auto scroll patch offset should skip to avoid jump.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - 修复了列表滚动位置在高度变化时的同步逻辑，避免在有缓存高度时发生不必要的滚动调整。

- **Tests**
  - 优化了测试用例中对元素高度的模拟方式，支持动态设置高度。
  - 新增用例，确保单个列表项高度变化时不会错误触发滚动事件。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->