### PR TITLE
update to @rc-component/virtual-list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ lib/
 ~*
 yarn.lock
 package-lock.json
+pnpm-lock.yaml
 !tests/__mocks__/rc-util/lib
 bun.lockb
 

--- a/examples/animate.tsx
+++ b/examples/animate.tsx
@@ -1,11 +1,9 @@
-/* eslint-disable arrow-body-style */
-
 import * as React from 'react';
-// @ts-ignore
-import CSSMotion from 'rc-animate/lib/CSSMotion';
+import CSSMotion from '@rc-component/motion';
+import type { CSSMotionRef } from '@rc-component/motion/lib/CSSMotion';
 import classNames from 'classnames';
 import List, { ListRef } from '../src/List';
-import useLayoutEffect from 'rc-util/lib/hooks/useLayoutEffect';
+import useLayoutEffect from '@rc-component/util/lib/hooks/useLayoutEffect';
 import './animate.less';
 
 let uuid = 0;
@@ -44,7 +42,7 @@ const getMaxHeight = (node: HTMLElement) => {
 };
 const getCollapsedHeight = () => ({ height: 0, opacity: 0 });
 
-const MyItem: React.ForwardRefRenderFunction<any, MyItemProps> = (
+const MyItem: React.ForwardRefRenderFunction<CSSMotionRef, MyItemProps> = (
   {
     id,
     uuid: itemUuid,
@@ -74,7 +72,7 @@ const MyItem: React.ForwardRefRenderFunction<any, MyItemProps> = (
       motionName="motion"
       motionAppear={motionAppear}
       onAppearStart={getCollapsedHeight}
-      onAppearActive={node => {
+      onAppearActive={(node) => {
         motionRef.current = true;
         return getMaxHeight(node);
       }}
@@ -135,7 +133,7 @@ const Demo = () => {
   const [animating, setAnimating] = React.useState(false);
   const [insertIndex, setInsertIndex] = React.useState<number>();
 
-  const listRef = React.useRef<ListRef>();
+  const listRef = React.useRef<ListRef>(null);
 
   const onClose = (id: string) => {
     setCloseMap({
@@ -145,7 +143,7 @@ const Demo = () => {
   };
 
   const onLeave = (id: string) => {
-    const newData = data.filter(item => item.id !== id);
+    const newData = data.filter((item) => item.id !== id);
     setData(newData);
   };
 
@@ -159,14 +157,14 @@ const Demo = () => {
   }
 
   const onInsertBefore = (id: string) => {
-    const index = data.findIndex(item => item.id === id);
+    const index = data.findIndex((item) => item.id === id);
     const newData = [...data.slice(0, index), genItem(), ...data.slice(index)];
     setInsertIndex(index);
     setData(newData);
     lockForAnimation();
   };
   const onInsertAfter = (id: string) => {
-    const index = data.findIndex(item => item.id === id) + 1;
+    const index = data.findIndex((item) => item.id === id) + 1;
     const newData = [...data.slice(0, index), genItem(), ...data.slice(index)];
     setInsertIndex(index);
     setData(newData);
@@ -187,10 +185,7 @@ const Demo = () => {
           itemKey="id"
           // disabled={animating}
           ref={listRef}
-          style={{
-            border: '1px solid red',
-            boxSizing: 'border-box',
-          }}
+          style={{ border: '1px solid red', boxSizing: 'border-box' }}
           // onSkipRender={onAppear}
           // onItemRemove={onAppear}
         >

--- a/examples/basic.tsx
+++ b/examples/basic.tsx
@@ -6,7 +6,7 @@ interface Item {
   id: number;
 }
 
-const MyItem: React.ForwardRefRenderFunction<any, Item> = ({ id }, ref) => (
+const MyItem: React.ForwardRefRenderFunction<HTMLSpanElement, Item> = ({ id }, ref) => (
   <span
     ref={ref}
     style={{

--- a/examples/height.tsx
+++ b/examples/height.tsx
@@ -6,7 +6,7 @@ interface Item {
   height: number;
 }
 
-const MyItem: React.ForwardRefRenderFunction<HTMLElement, Item> = ({ id, height }, ref) => {
+const MyItem: React.ForwardRefRenderFunction<HTMLSpanElement, Item> = ({ id, height }, ref) => {
   return (
     <span
       ref={ref}
@@ -50,7 +50,7 @@ const Demo = () => {
             boxSizing: 'border-box',
           }}
         >
-          {item => <ForwardMyItem {...item} />}
+          {(item) => <ForwardMyItem {...item} />}
         </List>
       </div>
     </React.StrictMode>

--- a/examples/nest.tsx
+++ b/examples/nest.tsx
@@ -13,7 +13,7 @@ for (let i = 0; i < 100; i += 1) {
   });
 }
 
-const MyItem: React.ForwardRefRenderFunction<any, Item> = ({ id }, ref) => (
+const MyItem: React.ForwardRefRenderFunction<HTMLDivElement, Item> = ({ id }, ref) => (
   <div style={{ padding: 20, background: 'yellow' }} ref={ref}>
     <List
       data={data}

--- a/examples/no-virtual.tsx
+++ b/examples/no-virtual.tsx
@@ -7,7 +7,7 @@ interface Item {
   height: number;
 }
 
-const MyItem: React.FC<Item> = ({ id, height }, ref) => {
+const MyItem: React.ForwardRefRenderFunction<HTMLSpanElement, Item> = ({ id, height }, ref) => {
   return (
     <span
       ref={ref}
@@ -50,7 +50,7 @@ const Demo = () => {
             boxSizing: 'border-box',
           }}
         >
-          {item => <ForwardMyItem {...(item as any)} />}
+          {(item) => <ForwardMyItem {...(item as any)} />}
         </List>
 
         <h2>Less Count</h2>
@@ -64,7 +64,7 @@ const Demo = () => {
             boxSizing: 'border-box',
           }}
         >
-          {item => <ForwardMyItem {...(item as any)} />}
+          {(item) => <ForwardMyItem {...(item as any)} />}
         </List>
 
         <h2>Less Item Height</h2>
@@ -78,7 +78,7 @@ const Demo = () => {
             boxSizing: 'border-box',
           }}
         >
-          {item => <ForwardMyItem {...(item as any)} />}
+          {(item) => <ForwardMyItem {...(item as any)} />}
         </List>
 
         <h2>Without Height</h2>
@@ -91,7 +91,7 @@ const Demo = () => {
             boxSizing: 'border-box',
           }}
         >
-          {item => <ForwardMyItem {...(item as any)} />}
+          {(item) => <ForwardMyItem {...(item as any)} />}
         </List>
       </div>
     </React.StrictMode>

--- a/examples/switch.tsx
+++ b/examples/switch.tsx
@@ -6,7 +6,7 @@ interface Item {
   id: number;
 }
 
-const MyItem: React.FC<Item> = ({ id }, ref) => (
+const MyItem: React.ForwardRefRenderFunction<HTMLSpanElement, Item> = ({ id }, ref) => (
   <span
     ref={ref}
     style={{
@@ -23,7 +23,7 @@ const MyItem: React.FC<Item> = ({ id }, ref) => (
   </span>
 );
 
-const ForwardMyItem = React.forwardRef(MyItem as any);
+const ForwardMyItem = React.forwardRef<HTMLSpanElement, Item>(MyItem);
 
 function getData(count: number) {
   const data: Item[] = [];
@@ -39,7 +39,7 @@ const Demo = () => {
   const [height, setHeight] = React.useState(200);
   const [data, setData] = React.useState(getData(20));
   const [fullHeight, setFullHeight] = React.useState(true);
-  const listRef = React.useRef<ListRef>();
+  const listRef = React.useRef<ListRef>(null);
 
   return (
     <React.StrictMode>
@@ -117,12 +117,9 @@ const Demo = () => {
           itemHeight={10}
           itemKey="id"
           fullHeight={fullHeight}
-          style={{
-            border: '1px solid red',
-            boxSizing: 'border-box',
-          }}
+          style={{ border: '1px solid red', boxSizing: 'border-box' }}
         >
-          {(item, _, props) => <ForwardMyItem {...(item as any)} {...props} />}
+          {(item, _, props) => <ForwardMyItem {...item} {...props} />}
         </List>
       </div>
     </React.StrictMode>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "rc-virtual-list",
-  "version": "3.18.6",
+  "name": "@rc-component/virtual-list",
+  "version": "1.0.0",
   "description": "React Virtual List Component",
   "engines": {
     "node": ">=8.x"
@@ -36,19 +36,23 @@
     "test": "rc-test",
     "now-build": "npm run build"
   },
-  "peerDependencies": {
-    "react": ">=16.9.0",
-    "react-dom": ">=16.9.0"
+  "dependencies": {
+    "@babel/runtime": "^7.20.0",
+    "@rc-component/resize-observer": "^1.0.0",
+    "@rc-component/util": "^1.2.1",
+    "classnames": "^2.2.6"
   },
   "devDependencies": {
     "@rc-component/father-plugin": "^1.0.2",
+    "@rc-component/motion": "^1.1.4",
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^12.1.5",
     "@types/classnames": "^2.2.10",
     "@types/enzyme": "^3.10.5",
     "@types/jest": "^25.1.3",
-    "@types/react": "^18.0.8",
-    "@types/react-dom": "^18.0.3",
+    "@types/node": "^22.15.18",
+    "@types/react": "^19.1.4",
+    "@types/react-dom": "^19.1.5",
     "@types/warning": "^3.0.0",
     "cheerio": "1.0.0-rc.12",
     "cross-env": "^5.2.0",
@@ -61,16 +65,13 @@
     "father": "^4.4.0",
     "glob": "^7.1.6",
     "np": "^5.0.3",
-    "rc-animate": "^2.9.1",
     "rc-test": "^7.0.15",
-    "react": "16.14.0",
-    "react-dom": "16.14.0",
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0",
     "typescript": "^5.0.0"
   },
-  "dependencies": {
-    "@babel/runtime": "^7.20.0",
-    "classnames": "^2.2.6",
-    "rc-resize-observer": "^1.0.0",
-    "rc-util": "^5.36.0"
+  "peerDependencies": {
+    "react": ">=18.0.0",
+    "react-dom": ">=18.0.0"
   }
 }

--- a/src/Filler.tsx
+++ b/src/Filler.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import ResizeObserver from 'rc-resize-observer';
+import ResizeObserver from '@rc-component/resize-observer';
 import classNames from 'classnames';
 
 export type InnerProps = Pick<React.HTMLAttributes<HTMLDivElement>, 'role' | 'id'>;
@@ -28,20 +28,10 @@ interface FillerProps {
 /**
  * Fill component to provided the scroll content real height.
  */
-const Filler = React.forwardRef(
+const Filler = React.forwardRef<HTMLDivElement, FillerProps>(
   (
-    {
-      height,
-      offsetY,
-      offsetX,
-      children,
-      prefixCls,
-      onInnerResize,
-      innerProps,
-      rtl,
-      extra,
-    }: FillerProps,
-    ref: React.Ref<HTMLDivElement>,
+    { height, offsetY, offsetX, children, prefixCls, onInnerResize, innerProps, rtl, extra },
+    ref,
   ) => {
     let outerStyle: React.CSSProperties = {};
 
@@ -80,9 +70,7 @@ const Filler = React.forwardRef(
         >
           <div
             style={innerStyle}
-            className={classNames({
-              [`${prefixCls}-holder-inner`]: prefixCls,
-            })}
+            className={classNames({ [`${prefixCls}-holder-inner`]: prefixCls })}
             ref={ref}
             {...innerProps}
           >
@@ -95,6 +83,8 @@ const Filler = React.forwardRef(
   },
 );
 
-Filler.displayName = 'Filler';
+if (process.env.NODE_ENV !== 'production') {
+  Filler.displayName = 'Filler';
+}
 
 export default Filler;

--- a/src/Item.tsx
+++ b/src/Item.tsx
@@ -6,11 +6,8 @@ export interface ItemProps {
 }
 
 export function Item({ children, setRef }: ItemProps) {
-  const refFunc = React.useCallback(node => {
+  const refFunc = React.useCallback((node: HTMLElement) => {
     setRef(node);
   }, []);
-
-  return React.cloneElement(children, {
-    ref: refFunc,
-  });
+  return React.cloneElement<any>(children, { ref: refFunc });
 }

--- a/src/List.tsx
+++ b/src/List.tsx
@@ -1,8 +1,8 @@
 import classNames from 'classnames';
-import type { ResizeObserverProps } from 'rc-resize-observer';
-import ResizeObserver from 'rc-resize-observer';
-import { useEvent } from 'rc-util';
-import useLayoutEffect from 'rc-util/lib/hooks/useLayoutEffect';
+import type { ResizeObserverProps } from '@rc-component/resize-observer';
+import ResizeObserver from '@rc-component/resize-observer';
+import { useEvent } from '@rc-component/util';
+import useLayoutEffect from '@rc-component/util/lib/hooks/useLayoutEffect';
 import * as React from 'react';
 import { useRef, useState } from 'react';
 import { flushSync } from 'react-dom';
@@ -148,9 +148,9 @@ export function RawList<T>(props: ListProps<T>, ref: React.Ref<ListRef>) {
 
   const mergedClassName = classNames(prefixCls, { [`${prefixCls}-rtl`]: isRTL }, className);
   const mergedData = data || EMPTY_DATA;
-  const componentRef = useRef<HTMLDivElement>();
-  const fillerInnerRef = useRef<HTMLDivElement>();
-  const containerRef = useRef<HTMLDivElement>();
+  const componentRef = useRef<HTMLDivElement>(null);
+  const fillerInnerRef = useRef<HTMLDivElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
 
   // =============================== Item Key ===============================
 
@@ -190,7 +190,7 @@ export function RawList<T>(props: ListProps<T>, ref: React.Ref<ListRef>) {
   // Put ref here since the range is generate by follow
   const rangeRef = useRef({ start: 0, end: mergedData.length });
 
-  const diffItemRef = useRef<T>();
+  const diffItemRef = useRef<T>(null);
   const [diffItem] = useDiffItem(mergedData, getKey);
   diffItemRef.current = diffItem;
 
@@ -309,8 +309,8 @@ export function RawList<T>(props: ListProps<T>, ref: React.Ref<ListRef>) {
   };
 
   // Hack on scrollbar to enable flash call
-  const verticalScrollBarRef = useRef<ScrollBarRef>();
-  const horizontalScrollBarRef = useRef<ScrollBarRef>();
+  const verticalScrollBarRef = useRef<ScrollBarRef>(null);
+  const horizontalScrollBarRef = useRef<ScrollBarRef>(null);
 
   const horizontalScrollBarSpinSize = React.useMemo(
     () => getSpinSize(size.width, scrollWidth),
@@ -675,7 +675,9 @@ export function RawList<T>(props: ListProps<T>, ref: React.Ref<ListRef>) {
 
 const List = React.forwardRef<ListRef, ListProps<any>>(RawList);
 
-List.displayName = 'List';
+if (process.env.NODE_ENV !== 'production') {
+  List.displayName = 'List';
+}
 
 export default List as <Item = any>(
   props: ListProps<Item> & { ref?: React.Ref<ListRef> },

--- a/src/ScrollBar.tsx
+++ b/src/ScrollBar.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames';
-import raf from 'rc-util/lib/raf';
+import raf from '@rc-component/util/lib/raf';
 import * as React from 'react';
 import { getPageXY } from './hooks/useScrollDrag';
 
@@ -49,15 +49,17 @@ const ScrollBar = React.forwardRef<ScrollBarRef, ScrollBarProps>((props, ref) =>
   const isLTR = !rtl;
 
   // ========================= Refs =========================
-  const scrollbarRef = React.useRef<HTMLDivElement>();
-  const thumbRef = React.useRef<HTMLDivElement>();
+  const scrollbarRef = React.useRef<HTMLDivElement>(null);
+  const thumbRef = React.useRef<HTMLDivElement>(null);
 
   // ======================= Visible ========================
   const [visible, setVisible] = React.useState(showScrollBar);
-  const visibleTimeoutRef = React.useRef<ReturnType<typeof setTimeout>>();
+  const visibleTimeoutRef = React.useRef<ReturnType<typeof setTimeout>>(null);
 
   const delayHidden = () => {
-    if (showScrollBar === true || showScrollBar === false) return;
+    if (showScrollBar === true || showScrollBar === false) {
+      return;
+    }
     clearTimeout(visibleTimeoutRef.current);
     setVisible(true);
     visibleTimeoutRef.current = setTimeout(() => {
@@ -120,9 +122,9 @@ const ScrollBar = React.forwardRef<ScrollBarRef, ScrollBarProps>((props, ref) =>
   }, []);
 
   // Pass to effect
-  const enableScrollRangeRef = React.useRef<number>();
+  const enableScrollRangeRef = React.useRef<number>(null);
   enableScrollRangeRef.current = enableScrollRange;
-  const enableOffsetRangeRef = React.useRef<number>();
+  const enableOffsetRangeRef = React.useRef<number>(null);
   enableOffsetRangeRef.current = enableOffsetRange;
 
   React.useEffect(() => {

--- a/src/hooks/useFrameWheel.ts
+++ b/src/hooks/useFrameWheel.ts
@@ -1,4 +1,4 @@
-import raf from 'rc-util/lib/raf';
+import raf from '@rc-component/util/lib/raf';
 import { useRef } from 'react';
 import isFF from '../utils/isFirefox';
 import useOriginScroll from './useOriginScroll';

--- a/src/hooks/useMobileTouchMove.ts
+++ b/src/hooks/useMobileTouchMove.ts
@@ -1,4 +1,4 @@
-import useLayoutEffect from 'rc-util/lib/hooks/useLayoutEffect';
+import useLayoutEffect from '@rc-component/util/lib/hooks/useLayoutEffect';
 import type * as React from 'react';
 import { useRef } from 'react';
 

--- a/src/hooks/useScrollDrag.ts
+++ b/src/hooks/useScrollDrag.ts
@@ -1,4 +1,4 @@
-import raf from 'rc-util/lib/raf';
+import raf from '@rc-component/util/lib/raf';
 import * as React from 'react';
 
 function smoothScrollOffset(offset: number) {

--- a/src/hooks/useScrollTo.tsx
+++ b/src/hooks/useScrollTo.tsx
@@ -1,10 +1,10 @@
 /* eslint-disable no-param-reassign */
 import * as React from 'react';
-import raf from 'rc-util/lib/raf';
+import raf from '@rc-component/util/lib/raf';
 import type { GetKey } from '../interface';
 import type CacheMap from '../utils/CacheMap';
-import useLayoutEffect from 'rc-util/lib/hooks/useLayoutEffect';
-import { warning } from 'rc-util';
+import useLayoutEffect from '@rc-component/util/lib/hooks/useLayoutEffect';
+import { warning } from '@rc-component/util';
 
 const MAX_TIMES = 10;
 
@@ -37,7 +37,7 @@ export default function useScrollTo<T>(
   syncScrollTop: (newTop: number) => void,
   triggerFlash: () => void,
 ): (arg: number | ScrollTarget) => void {
-  const scrollRef = React.useRef<number>();
+  const scrollRef = React.useRef<number>(null);
 
   const [syncState, setSyncState] = React.useState<{
     times: number;

--- a/src/mock.tsx
+++ b/src/mock.tsx
@@ -2,12 +2,14 @@ import * as React from 'react';
 import type { ListProps, ListRef } from './List';
 import { RawList } from './List';
 
-const List = React.forwardRef((props: ListProps<any>, ref: React.Ref<ListRef>) =>
+const List = React.forwardRef<ListRef, ListProps<any>>((props, ref) =>
   RawList({ ...props, virtual: false }, ref),
 ) as <Item = any>(
   props: React.PropsWithChildren<ListProps<Item>> & { ref?: React.Ref<ListRef> },
 ) => React.ReactElement;
 
-(List as any).displayName = 'List';
+if (process.env.NODE_ENV !== 'production') {
+  (List as any).displayName = 'List';
+}
 
 export default List;

--- a/tests/scroll.test.js
+++ b/tests/scroll.test.js
@@ -1,8 +1,8 @@
 import '@testing-library/jest-dom';
 import { act, createEvent, fireEvent, render } from '@testing-library/react';
 import { mount } from 'enzyme';
-import { _rs as onLibResize } from 'rc-resize-observer/lib/utils/observerUtil';
-import { resetWarned } from 'rc-util/lib/warning';
+import { _rs as onLibResize } from '@rc-component/resize-observer/lib/utils/observerUtil';
+import { resetWarned } from '@rc-component/util/lib/warning';
 import React from 'react';
 import List from '../src';
 import { spyElementPrototypes } from './utils/domHook';

--- a/tests/scrollWidth.test.tsx
+++ b/tests/scrollWidth.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { act, fireEvent, render } from '@testing-library/react';
-import { _rs as onLibResize } from 'rc-resize-observer/lib/utils/observerUtil';
-import { spyElementPrototypes } from 'rc-util/lib/test/domHook';
+import { _rs as onLibResize } from '@rc-component/resize-observer/lib/utils/observerUtil';
+import { spyElementPrototypes } from '@rc-component/util/lib/test/domHook';
 import React from 'react';
 import type { ListRef } from '../src';
 import List, { type ListProps } from '../src';


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新特性**
  - 包名更改为 "@rc-component/virtual-list"，版本重置为 1.0.0。
  - 依赖和 peerDependencies 升级，支持 React 18 及以上版本。

- **修复与优化**
  - 示例组件的 ref 类型声明更加精确，提升类型安全性。
  - 多处 React ref 初始化方式优化，提升类型一致性和健壮性。
  - 组件 displayName 只在非生产环境下设置，减少生产包体积。

- **依赖调整**
  - 移除旧依赖，新增并升级相关依赖以适配最新 React 生态。

- **测试**
  - 测试用例依赖路径更新，确保兼容新依赖结构。

- **其他**
  - 更新 .gitignore，忽略 pnpm-lock.yaml 文件。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->