### PR TITLE
fix: after selecting and dragging text, the table still scrolls even after releasing the mouse.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rc-virtual-list",
-  "version": "3.19.1",
+  "version": "3.19.2",
   "description": "React Virtual List Component",
   "engines": {
     "node": ">=8.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rc-virtual-list",
-  "version": "3.19.2",
+  "version": "3.19.1",
   "description": "React Virtual List Component",
   "engines": {
     "node": ">=8.x"

--- a/src/hooks/useScrollDrag.ts
+++ b/src/hooks/useScrollDrag.ts
@@ -90,7 +90,6 @@ export default function useScrollDrag(
       ele.ownerDocument.addEventListener('mouseup', onMouseUp);
       ele.ownerDocument.addEventListener('mousemove', onMouseMove);
       
-      // 添加额外的状态清理事件监听器
       ele.ownerDocument.addEventListener('dragstart', onDragStart);
       ele.ownerDocument.addEventListener('dragend', clearDragState);
 

--- a/src/hooks/useScrollDrag.ts
+++ b/src/hooks/useScrollDrag.ts
@@ -58,14 +58,6 @@ export default function useScrollDrag(
         }
       };
 
-      const onMouseUp = () => {
-        clearDragState();
-      };
-      
-      const onDragStart = () => {
-        clearDragState();
-      };
-
       const onMouseMove = (e: MouseEvent) => {
         if (mouseDownLock) {
           const mouseY = getPageXY(e, false);
@@ -86,18 +78,13 @@ export default function useScrollDrag(
       };
 
       ele.addEventListener('mousedown', onMouseDown);
-      ele.ownerDocument.addEventListener('mouseup', onMouseUp);
+      ele.ownerDocument.addEventListener('mouseup', clearDragState);
       ele.ownerDocument.addEventListener('mousemove', onMouseMove);
-      
-      ele.ownerDocument.addEventListener('dragstart', onDragStart);
-      ele.ownerDocument.addEventListener('dragend', clearDragState);
 
       return () => {
         ele.removeEventListener('mousedown', onMouseDown);
-        ele.ownerDocument.removeEventListener('mouseup', onMouseUp);
+        ele.ownerDocument.removeEventListener('mouseup', clearDragState);
         ele.ownerDocument.removeEventListener('mousemove', onMouseMove);
-        ele.ownerDocument.removeEventListener('dragstart', onDragStart);
-        ele.ownerDocument.removeEventListener('dragend', clearDragState);
         stopScroll();
       };
     }

--- a/src/hooks/useScrollDrag.ts
+++ b/src/hooks/useScrollDrag.ts
@@ -38,6 +38,12 @@ export default function useScrollDrag(
         });
       };
 
+      // 清理拖拽状态的统一函数
+      const clearDragState = () => {
+        mouseDownLock = false;
+        stopScroll();
+      };
+
       const onMouseDown = (e: MouseEvent) => {
         // Skip if element set draggable
         if ((e.target as HTMLElement).draggable || e.button !== 0) {
@@ -52,10 +58,28 @@ export default function useScrollDrag(
           mouseDownLock = true;
         }
       };
+
       const onMouseUp = () => {
-        mouseDownLock = false;
-        stopScroll();
+        clearDragState();
       };
+
+      // 当开始原生拖拽时清理状态
+      const onDragStart = () => {
+        clearDragState();
+      };
+
+      // 当失去焦点时清理状态
+      const onBlur = () => {
+        clearDragState();
+      };
+
+      // 当页面不可见时清理状态
+      const onVisibilityChange = () => {
+        if (document.hidden) {
+          clearDragState();
+        }
+      };
+
       const onMouseMove = (e: MouseEvent) => {
         if (mouseDownLock) {
           const mouseY = getPageXY(e, false);
@@ -78,11 +102,21 @@ export default function useScrollDrag(
       ele.addEventListener('mousedown', onMouseDown);
       ele.ownerDocument.addEventListener('mouseup', onMouseUp);
       ele.ownerDocument.addEventListener('mousemove', onMouseMove);
+      
+      // 添加额外的状态清理事件监听器
+      ele.ownerDocument.addEventListener('dragstart', onDragStart);
+      ele.ownerDocument.addEventListener('dragend', clearDragState);
+      window.addEventListener('blur', onBlur);
+      document.addEventListener('visibilitychange', onVisibilityChange);
 
       return () => {
         ele.removeEventListener('mousedown', onMouseDown);
         ele.ownerDocument.removeEventListener('mouseup', onMouseUp);
         ele.ownerDocument.removeEventListener('mousemove', onMouseMove);
+        ele.ownerDocument.removeEventListener('dragstart', onDragStart);
+        ele.ownerDocument.removeEventListener('dragend', clearDragState);
+        window.removeEventListener('blur', onBlur);
+        document.removeEventListener('visibilitychange', onVisibilityChange);
         stopScroll();
       };
     }

--- a/src/hooks/useScrollDrag.ts
+++ b/src/hooks/useScrollDrag.ts
@@ -80,15 +80,14 @@ export default function useScrollDrag(
       ele.addEventListener('mousedown', onMouseDown);
       ele.ownerDocument.addEventListener('mouseup', clearDragState);
       ele.ownerDocument.addEventListener('mousemove', onMouseMove);
-      
-      ele.ownerDocument.addEventListener('dragstart', clearDragState);
+
       ele.ownerDocument.addEventListener('dragend', clearDragState);
 
       return () => {
         ele.removeEventListener('mousedown', onMouseDown);
         ele.ownerDocument.removeEventListener('mouseup', clearDragState);
         ele.ownerDocument.removeEventListener('mousemove', onMouseMove);
-        ele.ownerDocument.removeEventListener('dragstart', clearDragState);
+
         ele.ownerDocument.removeEventListener('dragend', clearDragState);
         stopScroll();
       };

--- a/src/hooks/useScrollDrag.ts
+++ b/src/hooks/useScrollDrag.ts
@@ -62,22 +62,9 @@ export default function useScrollDrag(
       const onMouseUp = () => {
         clearDragState();
       };
-
-      // 当开始原生拖拽时清理状态
+      
       const onDragStart = () => {
         clearDragState();
-      };
-
-      // 当失去焦点时清理状态
-      const onBlur = () => {
-        clearDragState();
-      };
-
-      // 当页面不可见时清理状态
-      const onVisibilityChange = () => {
-        if (document.hidden) {
-          clearDragState();
-        }
       };
 
       const onMouseMove = (e: MouseEvent) => {
@@ -106,8 +93,6 @@ export default function useScrollDrag(
       // 添加额外的状态清理事件监听器
       ele.ownerDocument.addEventListener('dragstart', onDragStart);
       ele.ownerDocument.addEventListener('dragend', clearDragState);
-      window.addEventListener('blur', onBlur);
-      document.addEventListener('visibilitychange', onVisibilityChange);
 
       return () => {
         ele.removeEventListener('mousedown', onMouseDown);
@@ -115,8 +100,6 @@ export default function useScrollDrag(
         ele.ownerDocument.removeEventListener('mousemove', onMouseMove);
         ele.ownerDocument.removeEventListener('dragstart', onDragStart);
         ele.ownerDocument.removeEventListener('dragend', clearDragState);
-        window.removeEventListener('blur', onBlur);
-        document.removeEventListener('visibilitychange', onVisibilityChange);
         stopScroll();
       };
     }

--- a/src/hooks/useScrollDrag.ts
+++ b/src/hooks/useScrollDrag.ts
@@ -80,11 +80,16 @@ export default function useScrollDrag(
       ele.addEventListener('mousedown', onMouseDown);
       ele.ownerDocument.addEventListener('mouseup', clearDragState);
       ele.ownerDocument.addEventListener('mousemove', onMouseMove);
+      
+      ele.ownerDocument.addEventListener('dragstart', clearDragState);
+      ele.ownerDocument.addEventListener('dragend', clearDragState);
 
       return () => {
         ele.removeEventListener('mousedown', onMouseDown);
         ele.ownerDocument.removeEventListener('mouseup', clearDragState);
         ele.ownerDocument.removeEventListener('mousemove', onMouseMove);
+        ele.ownerDocument.removeEventListener('dragstart', clearDragState);
+        ele.ownerDocument.removeEventListener('dragend', clearDragState);
         stopScroll();
       };
     }

--- a/src/hooks/useScrollDrag.ts
+++ b/src/hooks/useScrollDrag.ts
@@ -38,7 +38,6 @@ export default function useScrollDrag(
         });
       };
 
-      // 清理拖拽状态的统一函数
       const clearDragState = () => {
         mouseDownLock = false;
         stopScroll();

--- a/tests/scroll.test.js
+++ b/tests/scroll.test.js
@@ -735,7 +735,6 @@ describe('List.Scroll', () => {
   it('should not scroll after drop table text', () => {
     
     const onScroll = jest.fn();
-    // 这两个事件绑定在 document
     const onDragStart = jest.fn();
     const onDragEnd = jest.fn();
     document.addEventListener('dragstart', onDragStart);
@@ -753,9 +752,8 @@ describe('List.Scroll', () => {
         {({ id }) => <li className="fixed-item">{id}</li>}
       </List>,
     );
-    // 选择第一个可见的 fixed-item 的文本内容
     const fixedItems = container.querySelectorAll('.fixed-item');
-    const targetItem = fixedItems[0]; // 使用第一个可见元素
+    const targetItem = fixedItems[0];
     if (targetItem) {
       const range = document.createRange();
       range.selectNodeContents(targetItem);
@@ -763,27 +761,22 @@ describe('List.Scroll', () => {
       selection.removeAllRanges();
       selection.addRange(range);
     }
-    // 选中 fixed-item 里的文本并拖拽文本到列表底部
     const listHolder = container.querySelector('.rc-virtual-list-holder');
     if (targetItem && listHolder) {
-      // 创建选区，选中 fixed-item 的文本
       const range = document.createRange();
       range.selectNodeContents(targetItem);
       const selection = window.getSelection();
       selection.removeAllRanges();
       selection.addRange(range);
 
-      // 模拟拖拽文本
       fireEvent.dragStart(targetItem, { bubbles: true });
 
-      // 拖拽到列表底部
       const rect = listHolder.getBoundingClientRect();
       fireEvent.dragOver(listHolder, {
         clientY: rect.bottom + 10,
         bubbles: true,
       });
 
-      // 松开鼠标
       fireEvent.drop(listHolder, {
         clientY: rect.bottom + 10,
         bubbles: true,
@@ -791,12 +784,10 @@ describe('List.Scroll', () => {
 
       fireEvent.dragEnd(targetItem, { bubbles: true });
     }
-    // 检查 onScroll 没有被触发
     expect(onScroll).not.toHaveBeenCalled();
     expect(onDragStart).toHaveBeenCalled();
     expect(onDragEnd).toHaveBeenCalled();
 
-    // 模拟鼠标移动到列表顶部
     if (listHolder) {
       const rect = listHolder.getBoundingClientRect();
       const mouseMoveEvent = new MouseEvent('mousemove', {
@@ -805,10 +796,8 @@ describe('List.Scroll', () => {
       });
       listHolder.dispatchEvent(mouseMoveEvent);
     }
-    // 检查 onScroll 没有被触发
     expect(onScroll).not.toHaveBeenCalled();
     
-    // 清理事件监听器
     document.removeEventListener('dragstart', onDragStart);
     document.removeEventListener('dragend', onDragEnd);
   });

--- a/tests/scroll.test.js
+++ b/tests/scroll.test.js
@@ -747,7 +747,7 @@ describe('List.Scroll', () => {
         {({ id }) => <li draggable>{id}</li>}
       </List>,
     );
-    // 选中第99个 fixed-item 的文本内容
+    // Select the text content of the 99th fixed-item
     const fixedItems = container.querySelectorAll('.fixed-item');
     const targetItem = fixedItems[99];
     if (targetItem) {
@@ -757,14 +757,14 @@ describe('List.Scroll', () => {
       selection.removeAllRanges();
       selection.addRange(range);
     }
-    // 模拟将选中的文本拖拽到列表最底部
+    // Simulate dragging the selected text to the bottom of the list
     const listHolder = container.querySelector('.rc-virtual-list-holder');
     if (targetItem && listHolder) {
-      // 创建拖拽事件
+      // Create drag event
       const dragStartEvent = new DragEvent('dragstart', { bubbles: true });
       targetItem.dispatchEvent(dragStartEvent);
 
-      // 拖拽到最底部
+      // Drag to the bottom
       const rect = listHolder.getBoundingClientRect();
       const dragOverEvent = new DragEvent('dragover', {
         bubbles: true,
@@ -772,7 +772,7 @@ describe('List.Scroll', () => {
       });
       listHolder.dispatchEvent(dragOverEvent);
 
-      // 松开鼠标
+      // Release mouse
       const dropEvent = new DragEvent('drop', {
         bubbles: true,
         clientY: rect.bottom + 10,
@@ -782,10 +782,10 @@ describe('List.Scroll', () => {
       const dragEndEvent = new DragEvent('dragend', { bubbles: true });
       targetItem.dispatchEvent(dragEndEvent);
     }
-    // 检查 onScroll 没有被触发
+    // Check that onScroll was not triggered
     expect(onScroll).not.toHaveBeenCalled();
 
-    // 模拟将鼠标移动到列表最顶部
+    // Simulate moving the mouse to the top of the list
     if (listHolder) {
       const rect = listHolder.getBoundingClientRect();
       const mouseMoveEvent = new MouseEvent('mousemove', {
@@ -794,7 +794,7 @@ describe('List.Scroll', () => {
       });
       listHolder.dispatchEvent(mouseMoveEvent);
     }
-    // 检查 onScroll 没有被触发
+    // Check that onScroll was not triggered
     expect(onScroll).not.toHaveBeenCalled();
   });
 });

--- a/tests/scroll.test.js
+++ b/tests/scroll.test.js
@@ -734,6 +734,15 @@ describe('List.Scroll', () => {
 
   it('should not scroll after drop table text', () => {
     
+    // Helper function to select text content of an element
+    const selectElementText = (element) => {
+      const range = document.createRange();
+      range.selectNodeContents(element);
+      const selection = window.getSelection();
+      selection.removeAllRanges();
+      selection.addRange(range);
+    };
+
     const onScroll = jest.fn();
     const onDragStart = jest.fn();
     const onDragEnd = jest.fn();
@@ -755,19 +764,11 @@ describe('List.Scroll', () => {
     const fixedItems = container.querySelectorAll('.fixed-item');
     const targetItem = fixedItems[0];
     if (targetItem) {
-      const range = document.createRange();
-      range.selectNodeContents(targetItem);
-      const selection = window.getSelection();
-      selection.removeAllRanges();
-      selection.addRange(range);
+      selectElementText(targetItem);
     }
     const listHolder = container.querySelector('.rc-virtual-list-holder');
     if (targetItem && listHolder) {
-      const range = document.createRange();
-      range.selectNodeContents(targetItem);
-      const selection = window.getSelection();
-      selection.removeAllRanges();
-      selection.addRange(range);
+      selectElementText(targetItem);
 
       fireEvent.dragStart(targetItem, { bubbles: true });
 


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

fix https://github.com/ant-design/ant-design/issues/53924
fix https://github.com/ant-design/ant-design/issues/54548

### 💡 Background and Solution
选择文本，鼠标按住文本拖拽到表格外边，松开鼠标，鼠标上下移动会触发表格滚动

https://github.com/user-attachments/assets/6168bfc7-b4d1-4d0d-8b15-29855d656f42


rc-virtual-list 的 useScrollDrag hook 监听 mouseup

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix virtual-list drag scrolling issue |
| 🇨🇳 Chinese | 修复 virtual-list 拖拽滚动异常 |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 修复在列表中拖拽并放下选中文本后可能继续触发滚动的问题：在文档级别处理鼠标松开与原生拖拽结束事件以正确终止拖拽滚动，提升交互稳定性。

* **Tests**
  * 新增回归测试，验证拖拽并放下文本不会触发额外滚动或滚动回调。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->