### PR TITLE
[codex] expose scrollTop in extraRender info

### DIFF
--- a/src/List.tsx
+++ b/src/List.tsx
@@ -1,8 +1,7 @@
 import { clsx } from 'clsx';
 import type { ResizeObserverProps } from '@rc-component/resize-observer';
 import ResizeObserver from '@rc-component/resize-observer';
-import { useEvent } from '@rc-component/util';
-import useLayoutEffect from '@rc-component/util/lib/hooks/useLayoutEffect';
+import { useEvent, useLayoutEffect } from '@rc-component/util';
 import * as React from 'react';
 import { useRef, useState } from 'react';
 import { flushSync } from 'react-dom';

--- a/src/List.tsx
+++ b/src/List.tsx
@@ -558,6 +558,7 @@ export function RawList<T>(props: ListProps<T>, ref: React.Ref<ListRef>) {
     end,
     virtual: inVirtual,
     offsetX: offsetLeft,
+    scrollTop: offsetTop,
     offsetY: fillerOffset,
     rtl: isRTL,
     getSize,

--- a/src/ScrollBar.tsx
+++ b/src/ScrollBar.tsx
@@ -1,5 +1,5 @@
 import { clsx } from 'clsx';
-import raf from '@rc-component/util/lib/raf';
+import { raf } from '@rc-component/util';
 import * as React from 'react';
 import { getPageXY } from './hooks/useScrollDrag';
 

--- a/src/hooks/useFrameWheel.ts
+++ b/src/hooks/useFrameWheel.ts
@@ -1,4 +1,4 @@
-import raf from '@rc-component/util/lib/raf';
+import { raf } from '@rc-component/util';
 import { useRef } from 'react';
 import isFF from '../utils/isFirefox';
 import useOriginScroll from './useOriginScroll';

--- a/src/hooks/useMobileTouchMove.ts
+++ b/src/hooks/useMobileTouchMove.ts
@@ -1,4 +1,4 @@
-import useLayoutEffect from '@rc-component/util/lib/hooks/useLayoutEffect';
+import { useLayoutEffect } from '@rc-component/util';
 import type * as React from 'react';
 import { useRef } from 'react';
 

--- a/src/hooks/useScrollDrag.ts
+++ b/src/hooks/useScrollDrag.ts
@@ -1,4 +1,4 @@
-import raf from '@rc-component/util/lib/raf';
+import { raf } from '@rc-component/util';
 import * as React from 'react';
 
 function smoothScrollOffset(offset: number) {

--- a/src/hooks/useScrollTo.tsx
+++ b/src/hooks/useScrollTo.tsx
@@ -1,10 +1,8 @@
 /* eslint-disable no-param-reassign */
 import * as React from 'react';
-import raf from '@rc-component/util/lib/raf';
+import { raf, useLayoutEffect, warning } from '@rc-component/util';
 import type { GetKey } from '../interface';
 import type CacheMap from '../utils/CacheMap';
-import useLayoutEffect from '@rc-component/util/lib/hooks/useLayoutEffect';
-import { warning } from '@rc-component/util';
 
 const MAX_TIMES = 10;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import List from './List';
 
-export type { ListRef, ListProps } from './List';
+export type { ListRef, ListProps, ScrollConfig, ScrollTo } from './List';
+export { default as MockList } from './mock';
 
 export default List;

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -21,6 +21,8 @@ export interface ExtraRenderInfo {
   virtual: boolean;
   /** Used for `scrollWidth` tell the horizontal offset */
   offsetX: number;
+  /** Current vertical scroll offset */
+  scrollTop: number;
   offsetY: number;
 
   rtl: boolean;

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -19,10 +19,11 @@ export interface ExtraRenderInfo {
   end: number;
   /** Is current in virtual render */
   virtual: boolean;
-  /** Used for `scrollWidth` tell the horizontal offset */
+  /** Horizontal scroll offset applied to rendered items when `scrollWidth` is set */
   offsetX: number;
-  /** Current vertical scroll offset */
+  /** Current vertical scrollTop of the holder element */
   scrollTop: number;
+  /** Vertical translate offset of the rendered filler content */
   offsetY: number;
 
   rtl: boolean;

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -19,11 +19,20 @@ export interface ExtraRenderInfo {
   end: number;
   /** Is current in virtual render */
   virtual: boolean;
-  /** Horizontal scroll offset applied to rendered items when `scrollWidth` is set */
+  /**
+   * Horizontal scroll offset applied to rendered items when `scrollWidth` is set.
+   * 当设置 `scrollWidth` 时，应用到已渲染元素上的横向滚动偏移量。
+   */
   offsetX: number;
-  /** Current vertical scrollTop of the holder element */
+  /**
+   * Current vertical scrollTop of the holder element.
+   * holder 元素当前真实的纵向 `scrollTop`，表示视口滚动到了哪里。
+   */
   scrollTop: number;
-  /** Vertical translate offset of the rendered filler content */
+  /**
+   * Vertical translate offset of the rendered filler content.
+   * 已渲染 filler 内容的纵向 `translateY` 偏移量，表示这一段内容被平移到虚拟列表中的哪个位置。
+   */
   offsetY: number;
 
   rtl: boolean;

--- a/tests/scroll.test.js
+++ b/tests/scroll.test.js
@@ -113,6 +113,30 @@ describe('List.Scroll', () => {
 
       wrapper.unmount();
     });
+
+    it('passes current scrollTop to extraRender', () => {
+      const listRef = React.createRef();
+      const extraRender = jest.fn(() => null);
+      const wrapper = genList({
+        itemHeight: 20,
+        height: 100,
+        data: genData(100),
+        ref: listRef,
+        extraRender,
+      });
+
+      listRef.current.scrollTo(80);
+      jest.runAllTimers();
+      wrapper.update();
+
+      expect(extraRender).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          scrollTop: 80,
+        }),
+      );
+
+      wrapper.unmount();
+    });
   });
 
   describe('scroll to object', () => {


### PR DESCRIPTION
## Summary

- Add `scrollTop` to `ExtraRenderInfo` so `extraRender` consumers can position overlay content against the current vertical scroll offset without reading DOM or stale refs.
- Pass the current internal `offsetTop` as `scrollTop` when building the `extraRender` info object.
- Cover the new field with a scroll test.

## Validation

- `npm test -- scroll.test.js --runInBand`
- `npm run lint` (passes with existing warnings)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 额外渲染回调现已提供滚动距离信息，支持基于滚动位置的动态渲染
  * 新增类型导出，提供更完整的 API 接口

* **文档**
  * 更新接口文档注释，完善滚动相关信息说明

* **测试**
  * 添加滚动功能测试用例，验证新增功能正确性

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/react-component/virtual-list/pull/357?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->