### PR TITLE
fix: defer virtual rendering until after first commit for SSR safety

### DIFF
--- a/src/List.tsx
+++ b/src/List.tsx
@@ -146,7 +146,16 @@ export function RawList<T>(props: ListProps<T>, ref: React.Ref<ListRef>) {
     () => Object.values(heights.maps).reduce((total, curr) => total + curr, 0),
     [heights.id, heights.maps],
   );
+  // Defer virtual rendering until after first commit so SSR emits stable, hydration-safe
+  // markup (no virtual scrollbar / Filler wrap that depends on client-side measurement).
+  // `useLayoutEffect` here only fires on the client, so `mounted` stays `false` on the
+  // server and on the first client render that hydrates the SSR output.
+  const [mounted, setMounted] = useState(false);
+  useLayoutEffect(() => {
+    setMounted(true);
+  }, []);
   const inVirtual =
+    mounted &&
     useVirtual &&
     data &&
     (Math.max(itemHeight * data.length, containerHeight) > height || !!scrollWidth);
@@ -587,7 +596,7 @@ export function RawList<T>(props: ListProps<T>, ref: React.Ref<ListRef>) {
   if (height) {
     componentStyle = { [fullHeight ? 'height' : 'maxHeight']: height, ...ScrollStyle };
 
-    if (useVirtual) {
+    if (inVirtual) {
       componentStyle.overflowY = 'hidden';
 
       if (scrollWidth) {

--- a/tests/ssr.test.tsx
+++ b/tests/ssr.test.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { renderToString } from 'react-dom/server';
+import List from '../src';
+
+const ITEM_HEIGHT = 20;
+
+function genData(count: number) {
+  return new Array(count).fill(null).map((_, index) => ({ id: String(index) }));
+}
+
+describe('List.ssr', () => {
+  function ssr(extra?: Record<string, any>) {
+    return renderToString(
+      <List<{ id: string }>
+        data={genData(100)}
+        height={100}
+        itemHeight={ITEM_HEIGHT}
+        itemKey="id"
+        {...extra}
+      >
+        {(item) => <div key={item.id}>{item.id}</div>}
+      </List>,
+    );
+  }
+
+  it('initial SSR render should not enter virtual mode (no scrollbar / Filler wrap)', () => {
+    const html = ssr();
+    expect(html).not.toContain('rc-virtual-list-scrollbar');
+    // No Filler outer wrap with translateY (only emitted when inVirtual is true)
+    expect(html).not.toContain('translateY');
+  });
+
+  it('initial SSR render should use native overflow:auto on holder', () => {
+    const html = ssr();
+    // overflow-y stays "auto" before mount measures the container
+    expect(html).toContain('overflow-y:auto');
+    expect(html).not.toContain('overflow-y:hidden');
+  });
+
+  it('initial SSR render should not render horizontal scrollbar even when scrollWidth is set', () => {
+    const html = ssr({ scrollWidth: 200 });
+    expect(html).not.toContain('rc-virtual-list-scrollbar');
+    expect(html).not.toContain('overflow-x:hidden');
+  });
+
+  it('initial SSR render emits all items so the page is readable without JS', () => {
+    const html = ssr();
+    // First and last item should both appear in SSR output
+    expect(html).toContain('>0</div>');
+    expect(html).toContain('>99</div>');
+  });
+});


### PR DESCRIPTION
## 背景

初次渲染（包括 SSR 以及客户端首次 hydrate 那一帧）拿不到容器实测尺寸，但现在只要传了 `scrollWidth`、或者 `itemHeight * data.length > height`，组件就会走进虚拟分支，吐出一段客户端无法一致复现的 DOM：

- `Filler` 外层包了一个 `height: …; position: relative; overflow: hidden` 的 wrap，内层挂着 `transform: translateY(0)`；
- `ant-table-tbody-virtual-scrollbar` 那种横向/纵向滚动条节点；
- holder 上 `overflow-y: hidden`（设了 `scrollWidth` 时还会 `overflow-x: hidden`）。

客户端挂载后 `ResizeObserver` 量到真实尺寸，再 re-render 一次。结果就是 SSR 输出和"挂载后的真实虚拟形态"对不上：要么出现 hydration mismatch，要么首屏闪烁，要么消费方（如 ant-design 的 `Table virtual`）只能用 `__mocks__` 把 `virtual: false` 硬塞回去绕开问题。

## 改动

`src/List.tsx`

- 新增 `mounted` 标志，初始 `false`，在 `useLayoutEffect` 里翻成 `true`（`@rc-component/util` 的版本，SSR 安全，server 端走 `useEffect`，不会触发 React 警告）；
- `inVirtual` 加一道 `mounted` 守卫，首次渲染永远不进虚拟分支；
- holder 的 `overflowY: 'hidden'` / `overflowX: 'hidden'` 守卫从 `useVirtual` 换成 `inVirtual`，让首次渲染保持原生的 `overflow-y: auto` fallback。

效果：SSR（以及对应的客户端首次渲染）渲染出来和非虚拟列表完全一样 —— 所有 item 都在 DOM 里、holder 走原生滚动、没有 scrollbar 节点、没有 `translateY` 包装。挂载后量到尺寸，再 re-render 进入真正的虚拟布局。

`tests/ssr.test.tsx`

- 新增 SSR 回归用例，直接调 `renderToString` 断言首屏输出**不**包含 scrollbar 节点、`translateY`、`overflow-y: hidden`，并且每一项 item 都**有**在 HTML 里。

## 自测

- [x] `npx rc-test` → 9 个 suite、279 个用例全过（含 4 个新增 SSR 用例）。
- [x] `npx eslint src/ --ext .tsx,.ts` → 无新增 warning。
- [x] 手动跑 Node SSR（`renderToString`，`data.length = 100`、`scrollWidth = 4`）输出确认：
  - 没有 `rc-virtual-list-scrollbar`；
  - 没有 `translateY`；
  - `overflow-y: auto`；
  - 100 条 item 全部输出。

🤖 Generated with [Claude Code](https://claude.com/claude-code)