### PR TITLE
Support scrollbar track click

### DIFF
--- a/src/ScrollBar.tsx
+++ b/src/ScrollBar.tsx
@@ -25,6 +25,25 @@ export interface ScrollBarRef {
   delayHidden: () => void;
 }
 
+function getScrollOffsetByThumbTop(
+  thumbTop: number,
+  enabledScrollRange: number,
+  enabledOffsetRange: number,
+) {
+  if (enabledScrollRange <= 0 || enabledOffsetRange <= 0) {
+    return 0;
+  }
+
+  const mergedThumbTop = Math.max(Math.min(thumbTop, enabledOffsetRange), 0);
+  const ptg: number = mergedThumbTop / enabledOffsetRange;
+
+  let nextScrollOffset = Math.ceil(ptg * enabledScrollRange);
+  nextScrollOffset = Math.max(nextScrollOffset, 0);
+  nextScrollOffset = Math.min(nextScrollOffset, enabledScrollRange);
+
+  return nextScrollOffset;
+}
+
 const ScrollBar = React.forwardRef<ScrollBarRef, ScrollBarProps>((props, ref) => {
   const {
     prefixCls,
@@ -79,9 +98,57 @@ const ScrollBar = React.forwardRef<ScrollBarRef, ScrollBarProps>((props, ref) =>
   }, [scrollOffset, enableScrollRange, enableOffsetRange]);
 
   // ====================== Container =======================
+  const isThumbTarget = (target: EventTarget | null) => {
+    return !!target && thumbRef.current?.contains(target as Node);
+  };
+
+  const scrollToTrackPosition = (e: React.MouseEvent | MouseEvent) => {
+    const scrollbarEle = scrollbarRef.current;
+
+    if (!scrollbarEle) {
+      return;
+    }
+
+    const rect = scrollbarEle.getBoundingClientRect();
+    const pagePosition = getPageXY(e, horizontal);
+    let nextTop: number;
+
+    if (!Number.isFinite(pagePosition)) {
+      return;
+    }
+
+    if (horizontal) {
+      const horizontalStart = isLTR ? rect.left : rect.right;
+
+      if (!Number.isFinite(horizontalStart)) {
+        return;
+      }
+
+      nextTop =
+        (isLTR ? pagePosition - horizontalStart : horizontalStart - pagePosition) - spinSize / 2;
+    } else {
+      if (!Number.isFinite(rect.top)) {
+        return;
+      }
+
+      nextTop = pagePosition - rect.top - spinSize / 2;
+    }
+
+    onScroll(
+      getScrollOffsetByThumbTop(nextTop, enableScrollRange, enableOffsetRange),
+      horizontal,
+    );
+  };
+
   const onContainerMouseDown: React.MouseEventHandler = (e) => {
     e.stopPropagation();
     e.preventDefault();
+
+    if (e.button !== 0 || isThumbTarget(e.target)) {
+      return;
+    }
+
+    scrollToTrackPosition(e);
   };
 
   // ======================== Thumb =========================
@@ -153,11 +220,11 @@ const ScrollBar = React.forwardRef<ScrollBarRef, ScrollBarProps>((props, ref) =>
           const tmpEnableScrollRange = enableScrollRangeRef.current;
           const tmpEnableOffsetRange = enableOffsetRangeRef.current;
 
-          const ptg: number = tmpEnableOffsetRange ? newTop / tmpEnableOffsetRange : 0;
-
-          let newScrollTop = Math.ceil(ptg * tmpEnableScrollRange);
-          newScrollTop = Math.max(newScrollTop, 0);
-          newScrollTop = Math.min(newScrollTop, tmpEnableScrollRange);
+          const newScrollTop = getScrollOffsetByThumbTop(
+            newTop,
+            tmpEnableScrollRange,
+            tmpEnableOffsetRange,
+          );
 
           moveRafId = raf(() => {
             onScroll(newScrollTop, horizontal);

--- a/tests/scroll.test.js
+++ b/tests/scroll.test.js
@@ -308,6 +308,23 @@ describe('List.Scroll', () => {
       expect(container.querySelector('ul').scrollTop > 0).toBeTruthy();
     });
 
+    it('click track to scroll', () => {
+      const { container } = genList({
+        itemHeight: 20,
+        height: 100,
+        data: genData(100),
+      });
+
+      act(() => {
+        const scrollbar = container.querySelector('.rc-virtual-list-scrollbar-vertical');
+        const mouseDownEvent = createEvent.mouseDown(scrollbar);
+        Object.defineProperty(mouseDownEvent, 'pageY', { value: 50 });
+        fireEvent(scrollbar, mouseDownEvent);
+      });
+
+      expect(container.querySelector('ul').scrollTop).toEqual(950);
+    });
+
     it('should show scrollbar when element has showScrollBar prop set to true', () => {
       jest.useFakeTimers();
       const listRef = React.createRef();

--- a/tests/scrollWidth.test.tsx
+++ b/tests/scrollWidth.test.tsx
@@ -42,6 +42,10 @@ describe('List.scrollWidth', () => {
       },
       getBoundingClientRect() {
         return {
+          top: 0,
+          bottom: holderHeight,
+          left: 0,
+          right: holderWidth,
           width: holderWidth,
           height: holderHeight,
         };
@@ -102,6 +106,41 @@ describe('List.scrollWidth', () => {
   });
 
   describe('trigger offset', () => {
+    it('click horizontal track to scroll', async () => {
+      const listRef = React.createRef<ListRef>();
+
+      const { container } = await genList({
+        itemHeight: ITEM_HEIGHT,
+        height: 100,
+        data: genData(100),
+        scrollWidth: 1000,
+        ref: listRef,
+      });
+
+      pageX = 30;
+      fireEvent.mouseDown(container.querySelector('.rc-virtual-list-scrollbar-horizontal')!);
+
+      expect(listRef.current.getScrollInfo()).toEqual({ x: 225, y: 0 });
+    });
+
+    it('click horizontal track to scroll in rtl', async () => {
+      const listRef = React.createRef<ListRef>();
+
+      const { container } = await genList({
+        itemHeight: ITEM_HEIGHT,
+        height: 100,
+        data: genData(100),
+        scrollWidth: 1000,
+        direction: 'rtl',
+        ref: listRef,
+      });
+
+      pageX = 30;
+      fireEvent.mouseDown(container.querySelector('.rc-virtual-list-scrollbar-horizontal')!);
+
+      expect(listRef.current.getScrollInfo()).toEqual({ x: -675, y: 0 });
+    });
+
     it('drag scrollbar', async () => {
       const onVirtualScroll = jest.fn();
       const listRef = React.createRef<ListRef>();


### PR DESCRIPTION
## 变更内容

- 为虚拟滚动下的自定义滚动条补充点击轨道快速定位能力。
- 抽出滚动条滑块位置到滚动偏移的计算逻辑，并复用于拖拽与轨道点击，保持边界处理一致。
- 新增竖向滚动条轨道点击的回归测试。

## 背景

Ant Design issue ant-design/ant-design#58499 反馈：Table 开启虚拟滚动后，自定义滚动条仅支持拖拽滑块或滚轮滚动，不支持点击滚动条轨道快速定位。该交互与浏览器原生滚动条体验不一致。

## 影响

虚拟滚动列表的自定义滚动条现在可以通过点击轨道直接跳转到对应滚动位置；点击滑块本身仍保持原来的拖拽行为。

## 验证

- `npm run lint`：通过，存在仓库既有 hooks warnings，无 error。
- `npm run tsc`：通过。
- `npm test -- tests/scroll.test.js --runInBand`：通过。
- `npm test -- tests/scrollWidth.test.tsx --runInBand`：通过。
- `git diff --check`：通过。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 优化滚动条拽动与点击轨道的换算逻辑，使滚动位置计算一致，并进行范围裁剪防止越界。
  * 仅在有效点击（左键且未点到滑块）时触发轨道滚动，避免误触发；点击后滚动到对应位置。
* **Tests**
  * 新增垂直轨道点击滚动用例，并补强水平滚动与 RTL 场景下的断言覆盖。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->