### PR TITLE
fix: restore classic JSX runtime

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "esnext",
     "moduleResolution": "bundler",
-    "jsx": "react-jsx",
+    "jsx": "react",
     "declaration": true,
     "skipLibCheck": true,
     "esModuleInterop": true,


### PR DESCRIPTION
## Summary

- Restore the TypeScript JSX emit to the classic React runtime.
- Keep the published output using `React.createElement` instead of importing `react/jsx-runtime`.
- Avoid bundling a build-time React JSX runtime into downstream UMD bundles.

## Test

- `npm run tsc`
- `npm test -- --runInBand`
- Temporary TS emit check confirmed the JSX output no longer imports `react/jsx-runtime`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 调整了 JSX 编译配置，提升了项目对 React 相关语法的兼容性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->