### PR TITLE
feat: expose resolved align to scrollTo offset callback

### DIFF
--- a/src/hooks/useScrollTo.tsx
+++ b/src/hooks/useScrollTo.tsx
@@ -19,6 +19,14 @@ export interface ScrollOffsetInfo {
    * 通过 key 获取元素在虚拟列表中的尺寸范围。
    */
   getSize: GetSize;
+  /**
+   * Resolved align direction. For `auto` this reads `'auto'` on the first
+   * measure pass (before the direction is decided) and settles to
+   * `'top'`/`'bottom'` on the pass that actually positions the item.
+   *
+   * 已解析的对齐方向。auto 在首帧测量时仍是 'auto'，定向后变 'top'/'bottom'。
+   */
+  align: ScrollAlign;
 }
 
 export type ScrollOffset = number | ((info: ScrollOffsetInfo) => number);
@@ -75,7 +83,8 @@ export default function useScrollTo<T>(
       collectHeight();
 
       const { targetAlign, originAlign, index, offset: rawOffset } = syncState;
-      const offset = getOffset(rawOffset, { getSize });
+      const mergedAlign = targetAlign || originAlign;
+      const offset = getOffset(rawOffset, { getSize, align: mergedAlign });
 
       const height = containerRef.current.clientHeight;
       let needCollectHeight = false;
@@ -84,8 +93,6 @@ export default function useScrollTo<T>(
 
       // Go to next frame if height not exist
       if (height) {
-        const mergedAlign = targetAlign || originAlign;
-
         // Get top & bottom
         let stackTop = 0;
         let itemTop = 0;

--- a/tests/scroll.test.js
+++ b/tests/scroll.test.js
@@ -99,7 +99,12 @@ describe('List.Scroll', () => {
   it('scrollTo null will show the scrollbar', () => {
     jest.useFakeTimers();
     const listRef = React.createRef();
-    const { container } = genList({ itemHeight: 20, height: 100, data: genData(100), ref: listRef });
+    const { container } = genList({
+      itemHeight: 20,
+      height: 100,
+      data: genData(100),
+      ref: listRef,
+    });
     act(() => {
       jest.runAllTimers();
       listRef.current.scrollTo(null);
@@ -211,9 +216,40 @@ describe('List.Scroll', () => {
 
       expect(offset).toHaveBeenCalledWith({
         getSize: expect.any(Function),
+        align: 'top',
       });
       expect(offset).toHaveBeenCalledTimes(2);
       expect(container.querySelector('ul').scrollTop).toEqual(540);
+    });
+
+    it('auto align exposes resolved direction to offset callback', () => {
+      const { scrollTo, container } = presetList();
+
+      // Target below viewport → auto pins to bottom
+      scrollTo(0);
+      const belowAligns = [];
+      scrollTo({
+        index: 30,
+        offset: ({ align }) => {
+          belowAligns.push(align);
+          return 0;
+        },
+      });
+      expect(belowAligns).toContain('bottom');
+      expect(container.querySelector('ul').scrollTop).toEqual(520);
+
+      // Target above viewport → auto pins to top
+      scrollTo(800);
+      const aboveAligns = [];
+      scrollTo({
+        index: 30,
+        offset: ({ align }) => {
+          aboveAligns.push(align);
+          return 0;
+        },
+      });
+      expect(aboveAligns).toContain('top');
+      expect(container.querySelector('ul').scrollTop).toEqual(600);
     });
 
     it('fallbacks invalid function offset to zero', () => {
@@ -328,15 +364,13 @@ describe('List.Scroll', () => {
     it('should show scrollbar when element has showScrollBar prop set to true', () => {
       jest.useFakeTimers();
       const listRef = React.createRef();
-      const { container } = genList(
-        {
-          itemHeight: 20,
-          height: 100,
-          data: genData(100),
-          ref: listRef,
-          showScrollBar: true,
-        }
-      );
+      const { container } = genList({
+        itemHeight: 20,
+        height: 100,
+        data: genData(100),
+        ref: listRef,
+        showScrollBar: true,
+      });
       act(() => {
         jest.runAllTimers();
       });


### PR DESCRIPTION
## Summary

- The functional `offset` of `scrollTo` receives `ScrollOffsetInfo`, which now also carries the **resolved `align` direction**.
- For `align: 'auto'`, `align` reads `'auto'` on the first measure pass (before the direction is decided) and settles to `'top'`/`'bottom'` on the pass that actually positions the item.
- Motivation: consumers that need a direction-dependent offset — e.g. compensating for a sticky group header only when the item is pinned to the **top** — previously had to reverse-engineer the direction from `getScrollInfo()` plus the item's position, duplicating the list's own decision. This exposes that decision directly, so the callback can simply branch on `align`.

Fully backward compatible: `align` is a new field on the info object; existing `offset` callbacks are unaffected.

## Test plan

- [x] Added a test asserting the callback receives `'top'` when the target is above the viewport and `'bottom'` when below.
- [x] Updated the existing functional-offset test to include the new `align` field.
- [x] `npm test` (scroll suite) — 36/36 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 优化滚动定位逻辑，在未指定对齐方式时，根据目标位置自动选择顶部或底部对齐。
  * 修复相关偏移量计算，确保滚动位置更加准确。

* **Tests**
  * 增加自动对齐与滚动位置的测试覆盖。
  * 整理现有测试代码格式。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->