### PR TITLE
fix: resolve scroll key against latest data

### DIFF
--- a/src/hooks/useScrollTo.tsx
+++ b/src/hooks/useScrollTo.tsx
@@ -61,15 +61,15 @@ export default function useScrollTo<T>(
 ): (arg: number | ScrollTarget) => void {
   const scrollRef = React.useRef<number | undefined>(undefined);
 
-  const [syncState, setSyncState] = React.useState<
-    {
-      times: number;
-      offset: ScrollOffset;
-      originAlign: ScrollAlign;
-      targetAlign?: 'top' | 'bottom';
-      lastTop?: number;
-    } & ({ index: number } | { key: React.Key })
-  >(null);
+  const [syncState, setSyncState] = React.useState<{
+    times: number;
+    index: number;
+    key?: React.Key;
+    offset: ScrollOffset;
+    originAlign: ScrollAlign;
+    targetAlign?: 'top' | 'bottom';
+    lastTop?: number;
+  }>(null);
 
   // ========================== Sync Scroll ==========================
   useLayoutEffect(() => {
@@ -84,7 +84,7 @@ export default function useScrollTo<T>(
 
       const { targetAlign, originAlign, offset: rawOffset } = syncState;
       const index =
-        'key' in syncState
+        syncState.index < 0 && 'key' in syncState
           ? data.findIndex((item) => getKey(item) === syncState.key)
           : syncState.index;
       const mergedAlign = targetAlign || originAlign;
@@ -165,6 +165,7 @@ export default function useScrollTo<T>(
         setSyncState({
           ...syncState,
           times: syncState.times + 1,
+          index,
           targetAlign: newTargetAlign,
           lastTop: targetTop,
         });
@@ -191,16 +192,9 @@ export default function useScrollTo<T>(
     if (typeof arg === 'number') {
       syncScrollTop(arg);
     } else if (arg && typeof arg === 'object') {
-      let target: { index: number } | { key: React.Key };
       const { align } = arg;
-
-      if ('index' in arg) {
-        target = { index: arg.index };
-      } else {
-        target = { key: arg.key };
-      }
-
       const { offset: rawOffset = 0 } = arg;
+      const target = 'index' in arg ? { index: arg.index } : { index: -1, key: arg.key };
 
       setSyncState({
         times: 0,

--- a/src/hooks/useScrollTo.tsx
+++ b/src/hooks/useScrollTo.tsx
@@ -84,14 +84,14 @@ export default function useScrollTo<T>(
 
       const { targetAlign, originAlign, offset: rawOffset } = syncState;
       const index =
-        syncState.index < 0 && 'key' in syncState
-          ? data.findIndex((item) => getKey(item) === syncState.key)
-          : syncState.index;
+        syncState.index >= 0
+          ? syncState.index
+          : data.findIndex((item) => getKey(item) === syncState.key);
       const mergedAlign = targetAlign || originAlign;
       const offset = getOffset(rawOffset, { getSize, align: mergedAlign });
 
       const height = containerRef.current.clientHeight;
-      let needCollectHeight = 'key' in syncState && index < 0;
+      let needCollectHeight = false;
       let newTargetAlign: 'top' | 'bottom' | null = targetAlign;
       let targetTop: number | null = null;
 
@@ -162,13 +162,13 @@ export default function useScrollTo<T>(
 
       // Trigger next effect
       if (needCollectHeight) {
-        setSyncState({
-          ...syncState,
-          times: syncState.times + 1,
+        setSyncState((prev) => ({
+          ...prev,
+          times: prev.times + 1,
           index,
           targetAlign: newTargetAlign,
           lastTop: targetTop,
-        });
+        }));
       }
     } else if (process.env.NODE_ENV !== 'production' && syncState?.times === MAX_TIMES) {
       warning(
@@ -192,13 +192,23 @@ export default function useScrollTo<T>(
     if (typeof arg === 'number') {
       syncScrollTop(arg);
     } else if (arg && typeof arg === 'object') {
+      let index: number;
+      let key: React.Key;
       const { align } = arg;
+
+      if ('index' in arg) {
+        ({ index } = arg);
+      } else {
+        key = arg.key;
+        index = data.findIndex((item) => getKey(item) === key);
+      }
+
       const { offset: rawOffset = 0 } = arg;
-      const target = 'index' in arg ? { index: arg.index } : { index: -1, key: arg.key };
 
       setSyncState({
         times: 0,
-        ...target,
+        index,
+        key,
         offset: rawOffset,
         originAlign: align,
       });

--- a/src/hooks/useScrollTo.tsx
+++ b/src/hooks/useScrollTo.tsx
@@ -61,14 +61,15 @@ export default function useScrollTo<T>(
 ): (arg: number | ScrollTarget) => void {
   const scrollRef = React.useRef<number | undefined>(undefined);
 
-  const [syncState, setSyncState] = React.useState<{
-    times: number;
-    index: number;
-    offset: ScrollOffset;
-    originAlign: ScrollAlign;
-    targetAlign?: 'top' | 'bottom';
-    lastTop?: number;
-  }>(null);
+  const [syncState, setSyncState] = React.useState<
+    {
+      times: number;
+      offset: ScrollOffset;
+      originAlign: ScrollAlign;
+      targetAlign?: 'top' | 'bottom';
+      lastTop?: number;
+    } & ({ index: number } | { key: React.Key })
+  >(null);
 
   // ========================== Sync Scroll ==========================
   useLayoutEffect(() => {
@@ -81,17 +82,21 @@ export default function useScrollTo<T>(
 
       collectHeight();
 
-      const { targetAlign, originAlign, index, offset: rawOffset } = syncState;
+      const { targetAlign, originAlign, offset: rawOffset } = syncState;
+      const index =
+        'key' in syncState
+          ? data.findIndex((item) => getKey(item) === syncState.key)
+          : syncState.index;
       const mergedAlign = targetAlign || originAlign;
       const offset = getOffset(rawOffset, { getSize, align: mergedAlign });
 
       const height = containerRef.current.clientHeight;
-      let needCollectHeight = false;
+      let needCollectHeight = 'key' in syncState && index < 0;
       let newTargetAlign: 'top' | 'bottom' | null = targetAlign;
       let targetTop: number | null = null;
 
       // Go to next frame if height not exist
-      if (height) {
+      if (height && index >= 0) {
         // Get top & bottom
         let stackTop = 0;
         let itemTop = 0;
@@ -186,20 +191,20 @@ export default function useScrollTo<T>(
     if (typeof arg === 'number') {
       syncScrollTop(arg);
     } else if (arg && typeof arg === 'object') {
-      let index: number;
+      let target: { index: number } | { key: React.Key };
       const { align } = arg;
 
       if ('index' in arg) {
-        ({ index } = arg);
+        target = { index: arg.index };
       } else {
-        index = data.findIndex((item) => getKey(item) === arg.key);
+        target = { key: arg.key };
       }
 
       const { offset: rawOffset = 0 } = arg;
 
       setSyncState({
         times: 0,
-        index,
+        ...target,
         offset: rawOffset,
         originAlign: align,
       });

--- a/tests/scroll.test.js
+++ b/tests/scroll.test.js
@@ -208,6 +208,31 @@ describe('List.Scroll', () => {
       expect(container.querySelector('ul').scrollTop).toEqual(520);
     });
 
+    it('refreshes key index when data changes', () => {
+      const ref = React.createRef();
+
+      function Demo() {
+        const [data, setData] = React.useState(genData(1));
+
+        return (
+          <>
+            <button
+              onClick={() => {
+                setData(genData(100));
+                ref.current.scrollTo({ key: '30', align: 'top' });
+              }}
+            />
+            {genNode({ itemHeight: 20, height: 100, data, ref })}
+          </>
+        );
+      }
+
+      const { container } = render(<Demo />);
+      fireEvent.click(container.querySelector('button'));
+
+      expect(container.querySelector('ul').scrollTop).toEqual(600);
+    });
+
     it('supports function offset with getSize info', () => {
       const { scrollTo, container } = presetList();
       const offset = jest.fn(({ getSize }) => getSize('2').bottom);


### PR DESCRIPTION
## Summary

Resolve `scrollTo({ key })` against the latest list data during scroll retries.

## Root cause

The key was converted to an index when `scrollTo` was called. If the same update added the target item, retries kept using the stale `-1` index and could not scroll to it.

## Changes

- Preserve key-based scroll targets in retry state
- Resolve the key from the latest data while its index is unavailable
- Cache the resolved index for subsequent measurement retries
- Add a regression test for scrolling while data expands

## Test

- `ut test -- --runInBand`
- `ut run tsc`
- `ut run lint -- src/hooks/useScrollTo.tsx tests/scroll.test.js`

Related to ant-design/ant-design#58841.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 滚动定位支持通过唯一键保存并恢复目标位置。
  - 数据更新后，可按指定键重新定位到对应内容。

- **问题修复**
  - 优化滚动同步逻辑，确保目标数据加载后正确计算并恢复滚动位置。
  - 改进滚动请求状态管理，提升重试和定位过程的稳定性。

- **测试**
  - 新增数据扩展后按键定位滚动位置的验证。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->