### PR TITLE
fix: retry key scroll after data update

### DIFF
--- a/src/hooks/useScrollTo.tsx
+++ b/src/hooks/useScrollTo.tsx
@@ -91,7 +91,7 @@ export default function useScrollTo<T>(
       const offset = getOffset(rawOffset, { getSize, align: mergedAlign });
 
       const height = containerRef.current.clientHeight;
-      let needCollectHeight = false;
+      let needCollectHeight = index < 0;
       let newTargetAlign: 'top' | 'bottom' | null = targetAlign;
       let targetTop: number | null = null;
 

--- a/tests/scroll.test.js
+++ b/tests/scroll.test.js
@@ -208,17 +208,24 @@ describe('List.Scroll', () => {
       expect(container.querySelector('ul').scrollTop).toEqual(520);
     });
 
-    it('refreshes key index when data changes', () => {
+    it('retries key scroll when data changes after layout', () => {
       const ref = React.createRef();
 
       function Demo() {
         const [data, setData] = React.useState(genData(1));
+        const [update, setUpdate] = React.useState(false);
+
+        React.useLayoutEffect(() => {
+          if (update) {
+            setData(genData(100));
+          }
+        }, [update]);
 
         return (
           <>
             <button
               onClick={() => {
-                setData(genData(100));
+                setUpdate(true);
                 ref.current.scrollTo({ key: '30', align: 'top' });
               }}
             />


### PR DESCRIPTION
## Summary

Retry key-based scrolling while its target index is unresolved, allowing data added by a later layout update to be found.

## Root cause

#376 retried key lookup only when a scroll measurement retry was already needed. If the target data appeared after the first layout pass, `needCollectHeight` stayed false and no retry was scheduled.

The previous regression test updated data in the same event batch as `scrollTo`, so the first layout pass already saw the target and did not expose this gap.

## Changes

- Continue retrying while the resolved index is negative
- Update the regression test so data changes in a later layout effect

## Test

- Confirmed the updated regression test fails on `master` with `scrollTop = 0`
- `ut test -- tests/scroll.test.js --runInBand`
- `ut test -- --runInBand`
- `ut run tsc`
- `eslint src/hooks/useScrollTo.tsx tests/scroll.test.js`

Follow-up to #376. Related to ant-design/ant-design#58841.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 修复目标索引无效时滚动同步未触发高度收集的问题。
  * 优化数据更新后的滚动重试，确保布局完成后能够滚动到目标位置。
* **Tests**
  * 增加布局变化后滚动位置校验，提升滚动行为的可靠性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->