### PR TITLE
ci: fix React Doctor workflow

### DIFF
--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -3,10 +3,14 @@ name: React Doctor
 on:
   pull_request:
     branches: [master]
+  push:
+    branches: [master]
 
 permissions:
   contents: read
   pull-requests: write
+  issues: write
+  statuses: write
 
 concurrency:
   group: react-doctor-${{ github.event.pull_request.number || github.ref }}
@@ -18,5 +22,6 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
+          fetch-depth: 0
           persist-credentials: false
-      - uses: millionco/react-doctor@964622bf15fa5f8eef7e05196407aa08dc779087 # v2.2.7
+      - uses: millionco/react-doctor@01820bb4fd4d0a4aebcd8df2b2a143a098649cb2


### PR DESCRIPTION
- add push trigger for the default branch
- grant issues: write and statuses: write permissions
- fetch full Git history (fetch-depth: 0)
- update action pin to v2.2.8
- remove obsolete github-token input where applicable

## Context

https://github.com/react-component/table/pull/1503

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **工程改进**
  * React Doctor 检查现已支持在 `master` 分支推送时自动运行。
  * 优化了代码检查流程的权限配置和历史记录获取，提升检查结果的完整性与可靠性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->